### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -60,4 +60,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/build-controller-image.yml
+++ b/.github/workflows/build-controller-image.yml
@@ -60,4 +60,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/build-drone-image.yml
+++ b/.github/workflows/build-drone-image.yml
@@ -60,4 +60,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -6,7 +6,6 @@ on:
     paths:
     - 'dev/test-server/**'
     - '.github/workflows/build-test-image.yml'
-    paths-ignore: [ "/docs" ]
 
 env:
   REGISTRY: ghcr.io
@@ -51,4 +50,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64


### PR DESCRIPTION
`arm64` seems to be breaking the build by causing a timeout at 45(!) minutes.

`paths-ignore` in `build-test-image.yml` is redundant.