### PR TITLE
Update bollard commit hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "bollard"
 version = "0.13.0"
-source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#3dee487c8493096b8e67ff717a38ea0e9761cf18"
+source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#7f949271557c20bfb03e50765660ac20c634fb6f"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -210,8 +210,8 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.42.0-rc.4"
-source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#3dee487c8493096b8e67ff717a38ea0e9761cf18"
+version = "1.42.0-rc.6"
+source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#7f949271557c20bfb03e50765660ac20c634fb6f"
 dependencies = [
  "serde",
  "serde_with",
@@ -560,33 +560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dotenvy"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
-dependencies = [
- "dirs",
-]
+checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "ed25519"
@@ -1812,17 +1789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
I broke the build by force-pushing to our bollard clone. This will all be cleaned up soon when our bollard changes are merged into main.