### PR TITLE
Report drone version in liveness ping

### DIFF
--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -77,6 +77,7 @@ impl Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
     fn date(date: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(date).unwrap().into()
@@ -102,7 +103,7 @@ mod tests {
             &DroneStatusMessage {
                 drone_id: drone_id.clone(),
                 cluster: ClusterName::new("mycluster.test"),
-                capacity: 100,
+                drone_version: PLANE_VERSION.to_string(),
             },
         );
 
@@ -124,7 +125,7 @@ mod tests {
             &DroneStatusMessage {
                 drone_id: DroneId::new_random(),
                 cluster: ClusterName::new("mycluster1.test"),
-                capacity: 100,
+                drone_version: PLANE_VERSION.to_string(),
             },
         );
 
@@ -146,7 +147,7 @@ mod tests {
             &DroneStatusMessage {
                 drone_id: DroneId::new_random(),
                 cluster: ClusterName::new("mycluster.test"),
-                capacity: 100,
+                drone_version: PLANE_VERSION.to_string(),
             },
         );
 

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -185,7 +185,7 @@ impl BackendStatsMessage {
 pub struct DroneStatusMessage {
     pub drone_id: DroneId,
     pub cluster: ClusterName,
-    pub capacity: u32,
+    pub drone_version: String,
 }
 
 impl TypedMessage for DroneStatusMessage {

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -17,6 +17,8 @@ use plane_dev::{
 use std::time::Duration;
 use tokio::time::sleep;
 
+const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 struct MockAgent {
     nats: TypedNats,
 }
@@ -99,9 +101,9 @@ async fn one_drone_available() -> Result<()> {
 
     nats_conn
         .publish(&DroneStatusMessage {
-            capacity: 100,
             cluster: ClusterName::new("plane.test"),
             drone_id: drone_id.clone(),
+            drone_version: PLANE_VERSION.to_string(),
         })
         .await?;
 

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -13,6 +13,8 @@ use plane_core::{
 };
 use std::{net::IpAddr, time::Duration};
 
+const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 mod backend;
 mod docker;
 mod executor;
@@ -103,8 +105,8 @@ async fn ready_loop(nc: TypedNats, drone_id: &DroneId, cluster: ClusterName) -> 
     loop {
         nc.publish_jetstream(&DroneStatusMessage {
             drone_id: drone_id.clone(),
-            capacity: 100,
             cluster: cluster.clone(),
+            drone_version: PLANE_VERSION.to_string(),
         })
         .await
         .log_error("Error in ready loop.");


### PR DESCRIPTION
`CARGO_PKG_VERSION` is [set by cargo at compile time](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates). The Rust [`env` macro](https://doc.rust-lang.org/std/macro.env.html) will read a value at compile time and insert it into the source.

This also removes the `capacity` value from the liveness ping. It was a placeholder that we never used, and probably does not represent how we want to do scheduling.