### PR TITLE
subscribe to drone status message as a regular subscription - not a jetstream

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn run_scheduler(nats: TypedNats) -> NeverResult {
     tracing::info!("Subscribed to spawn requests.");
 
     let mut status_sub = nats
-        .subscribe_jetstream(DroneStatusMessage::subscribe_subject())
+        .subscribe(DroneStatusMessage::subscribe_subject())
         .await?;
     tracing::info!("Subscribed to drone status messages.");
 
@@ -31,7 +31,7 @@ pub async fn run_scheduler(nats: TypedNats) -> NeverResult {
             status_msg = status_sub.next() => {
                 tracing::debug!(?status_msg, "Got drone status");
                 if let Some(status_msg) = status_msg? {
-                    scheduler.update_status(Utc::now(), &status_msg);
+                    scheduler.update_status(Utc::now(), &status_msg.value);
                 } else {
                     return Err(anyhow!("status_sub.next() returned None."));
                 }


### PR DESCRIPTION
I noticed that Plane was creating a Jetstream here when [the equivalent code in the platform](https://github.com/drifting-in-space/p2/blob/main/jamsocket/src/platform/mod.rs#L32-L34) is just using a regular nats subscription. Could this be related?