### PR TITLE
Handle NATS parse errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
                     .await?
             };
 
-            while let Some(message) = sub.next().await? {
+            while let Some(message) = sub.next().await {
                 println!(
                     "{}\t{}\t{}",
                     message.backend.to_string().bright_cyan(),

--- a/controller/src/dns/mod.rs
+++ b/controller/src/dns/mod.rs
@@ -69,7 +69,7 @@ impl ClusterDnsServer {
                     .subscribe_jetstream(SetDnsRecord::subscribe_subject())
                     .await?;
 
-                while let Some(v) = stream.next().await? {
+                while let Some(v) = stream.next().await {
                     match v.kind {
                         DnsRecordType::A => {
                             let ip: Ipv4Addr = match v.value.parse() {

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -87,7 +87,7 @@ impl MockController {
             "Should receive DNS message.",
             self.dns_subscription.next(),
         )
-        .await?
+        .await
         .map(|d| d.value)
         .ok_or_else(|| anyhow!("Expected a DNS record."))
     }
@@ -104,7 +104,7 @@ impl MockController {
             "Should receive drone connect message.",
             self.drone_connect_response_subscription.next(),
         )
-        .await?
+        .await
         .unwrap();
 
         assert_eq!(ClusterName::new(CLUSTER_DOMAIN), message.value.cluster);
@@ -130,7 +130,7 @@ impl MockController {
             "Should receive status message from drone.",
             status_sub.next(),
         )
-        .await?
+        .await
         .unwrap();
 
         assert_eq!(drone_id, &message.value.drone_id);
@@ -186,7 +186,6 @@ impl BackendStateSubscription {
             )
             .await
             .unwrap()
-            .unwrap()
             .value
             .state
         );
@@ -208,7 +207,7 @@ impl BackendStateSubscription {
             let next = tokio::time::timeout_at(deadline, self.sub.next()).await;
 
             match next {
-                Ok(Ok(Some(v))) => {
+                Ok(Some(v)) => {
                     if v.value.state == desired_state {
                         tracing::info!(?desired_state, "State became desired state.");
                         return Ok(())
@@ -341,7 +340,7 @@ async fn stats_are_acquired() -> Result<()> {
         "Waiting for stats message.",
         stats_subscription.next(),
     )
-    .await?
+    .await
     .unwrap();
     assert!(stat.value.cpu_use_percent >= 0.);
     assert!(stat.value.mem_use_percent >= 0.);

--- a/dev/tests/cert.rs
+++ b/dev/tests/cert.rs
@@ -28,7 +28,7 @@ impl DummyDnsHandler {
             .subscribe(SetAcmeDnsRecord::subscribe_subject())
             .await?;
         let handle = spawn_timeout(10_000, "Should get ACME DNS request.", async move {
-            let message = dns_sub.next().await.unwrap().unwrap();
+            let message = dns_sub.next().await.unwrap();
             assert_eq!(expect_domain, message.value.cluster);
             message.respond(&true).await?;
             Ok(())

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -45,7 +45,7 @@ impl MockAgent {
 
         // Expect a spawn request from the scheduler.
         let result = timeout(1_000, "Agent should receive spawn request.", sub.next())
-            .await?
+            .await
             .unwrap();
 
         // Ensure that the SpawnRequest is as expected.

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -57,7 +57,7 @@ async fn listen_for_spawn_requests(
         let req = sub.next().await;
 
         match req {
-            Ok(Some(req)) => {
+            Some(req) => {
                 let executor = executor.clone();
 
                 req.respond(&true).await?;
@@ -65,10 +65,7 @@ async fn listen_for_spawn_requests(
                     executor.start_backend(&req.value).await;
                 });
             }
-            Ok(None) => return Err(anyhow!("Spawn request subscription closed.")),
-            Err(error) => {
-                tracing::error!(?error, "Non-fatal error when listening for spawn requests.")
-            }
+            None => return Err(anyhow!("Spawn request subscription closed.")),
         }
     }
 }
@@ -81,19 +78,13 @@ async fn listen_for_termination_requests(executor: Executor, nats: TypedNats) ->
     loop {
         let req = sub.next().await;
         match req {
-            Ok(Some(req)) => {
+            Some(req) => {
                 let executor = executor.clone();
 
                 req.respond(&true).await?;
                 tokio::spawn(async move { executor.kill_backend(&req.value).await });
             }
-            Ok(None) => return Err(anyhow!("Termination request subscription closed.")),
-            Err(error) => {
-                tracing::error!(
-                    ?error,
-                    "Non-fatal error when listening for termination requests."
-                )
-            }
+            None => return Err(anyhow!("Termination request subscription closed.")),
         }
     }
 }


### PR DESCRIPTION
Currently, NATS subscriptions (both jetstream and not) return a `Result<Option<_>>`, with the semantics:

- `Ok(Some(_))` means that a value was successfully parsed from the stream.
- `Ok(None)` means that the stream was closed without error.
- `Err(_)` means that an error occurred retrieving the value.

This means that the caller has been responsible for handling these errors. In practice, we usually allowed these errors to bubble up and terminate the process, which was only intended as an interim solution.

The ideal behavior is for the code calling the subscriber to be able to have a reliable stream of (error-free) data, but to log an error if a parse error occurs. This PR achieves this by moving the error handling (logging) into the subscribers.

