### PR TITLE
Add ready field to DroneStatusMessage to support draining (#129)

### DIFF
--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -104,6 +104,7 @@ mod tests {
                 drone_id: drone_id.clone(),
                 cluster: ClusterName::new("mycluster.test"),
                 drone_version: PLANE_VERSION.to_string(),
+                ready: true,
             },
         );
 
@@ -126,6 +127,7 @@ mod tests {
                 drone_id: DroneId::new_random(),
                 cluster: ClusterName::new("mycluster1.test"),
                 drone_version: PLANE_VERSION.to_string(),
+                ready: true,
             },
         );
 
@@ -148,6 +150,7 @@ mod tests {
                 drone_id: DroneId::new_random(),
                 cluster: ClusterName::new("mycluster.test"),
                 drone_version: PLANE_VERSION.to_string(),
+                ready: true,
             },
         );
 

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -188,6 +188,16 @@ pub struct DroneStatusMessage {
     pub drone_id: DroneId,
     pub cluster: ClusterName,
     pub drone_version: String,
+
+    /// Indicates that a drone is ready to have backends scheduled to it.
+    /// When a drone has been told to drain or is otherwise unable to have
+    /// backends scheduled to it, this is set to false.
+    #[serde(default="default_ready")]
+    pub ready: bool,
+}
+
+fn default_ready() -> bool {
+    true
 }
 
 impl TypedMessage for DroneStatusMessage {

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -104,6 +104,7 @@ async fn one_drone_available() -> Result<()> {
             cluster: ClusterName::new("plane.test"),
             drone_id: drone_id.clone(),
             drone_version: PLANE_VERSION.to_string(),
+            ready: true,
         })
         .await?;
 

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -98,6 +98,7 @@ async fn ready_loop(nc: TypedNats, drone_id: &DroneId, cluster: ClusterName) -> 
             drone_id: drone_id.clone(),
             cluster: cluster.clone(),
             drone_version: PLANE_VERSION.to_string(),
+            ready: true,
         })
         .await
         .log_error("Error in ready loop.");


### PR DESCRIPTION
This adds a `ready` field to `DroneStatusMessage` which will be used to support draining (#129).

The field is currently always set to `true`, and is not respected by the scheduler.