### PR TITLE
Add timings for certain startup tasks

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -5,6 +5,7 @@ use plane_core::{
     messages::scheduler::{ScheduleRequest, ScheduleResponse},
     nats::TypedNats,
     NeverResult,
+    timing::Timer,
 };
 use scheduler::Scheduler;
 use tokio::select;
@@ -43,8 +44,18 @@ pub async fn run_scheduler(nats: TypedNats) -> NeverResult {
                         tracing::info!(spawn_request=?schedule_request.value, "Got spawn request");
                         let result = match scheduler.schedule(&schedule_request.value.cluster, Utc::now()) {
                             Ok(drone_id) => {
+                                let timer = Timer::new();
                                 let spawn_request = schedule_request.value.schedule(&drone_id);
                                 match nats.request(&spawn_request).await {
+                                    Ok(true) => {
+                                        tracing::info!(
+                                            duration=?timer.duration(),
+                                            backend_id=%spawn_request.backend_id,
+                                            %drone_id,
+                                            "Drone accepted backend."
+                                        );
+                                        ScheduleResponse::Scheduled { drone: drone_id, backend_id: spawn_request.backend_id }
+                                    }
                                     Ok(false) => {
                                         tracing::warn!("No drone available.");
                                         ScheduleResponse::NoDroneAvailable
@@ -53,7 +64,6 @@ pub async fn run_scheduler(nats: TypedNats) -> NeverResult {
                                         tracing::warn!(?error, "Scheduler returned error.");
                                         ScheduleResponse::NoDroneAvailable
                                     },
-                                    Ok(true) => ScheduleResponse::Scheduled { drone: drone_id, backend_id: spawn_request.backend_id }
                                 }
                             },
                             Err(error) => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod logging;
 pub mod messages;
 pub mod nats;
 pub mod nats_connection;
+pub mod timing;
 pub mod retry;
 pub mod types;
 

--- a/core/src/timing.rs
+++ b/core/src/timing.rs
@@ -1,0 +1,17 @@
+use std::time::{Instant, Duration};
+
+pub struct Timer {
+    started: Instant,
+}
+
+impl Timer {
+    pub fn new() -> Self {
+        Timer {
+            started: Instant::now(),
+        }
+    }
+
+    pub fn duration(&self) -> Duration {
+        Instant::now().duration_since(self.started)
+    }
+}


### PR DESCRIPTION
This creates a `Timer` struct, and uses it to record timings of a number of things:
- Scheduling a backend
- Pulling an image
- Creating a container
- Starting a container

Ideally I'd like to be able to generate a full flamegraph from scheduler request to backend ready, but this is a start in that direction.