### PR TITLE
CORS header for 404

### DIFF
--- a/drone/src/proxy/service.rs
+++ b/drone/src/proxy/service.rs
@@ -240,6 +240,7 @@ impl ProxyService {
 
         Ok(Response::builder()
             .status(StatusCode::NOT_FOUND)
+            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
             .body(Body::empty())?)
     }
 


### PR DESCRIPTION
When a backend is running, the backend can set its own CORS headers. However, after a backend is shut down, it defaults back to the strict default CORS settings. This change sets the CORS header for the 404 page to accept all origins.

Security-wise, this doesn't expose anything that wasn't exposed before. The 404 page returned doesn't look at authentication headers or cookies, it simply reveals that a backend no longer exists, which any internet-connected device could already determine.