### PR TITLE
Support drone draining (#129)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         cache-on-failure: true
 
     - name: Install cargo-nextest
-      run: cargo install cargo-nextest
+      run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
     - name: Run tests
       run: cargo nextest run -j 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "async-nats"
@@ -91,7 +91,7 @@ dependencies = [
  "serde_nanos",
  "serde_repr",
  "subslice",
- "time 0.3.15",
+ "time 0.3.17",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -138,9 +138,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64-url"
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -237,9 +237,9 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.17"
+version = "4.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
+checksum = "426eed9136e68a14d9de937db20cfd79fcc25c09709872e8005897c618a8365e"
 dependencies = [
  "atty",
  "bitflags",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "4.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "685fbc59da060ed2cd3d79c86970ee95386b5e5fc69d9cad881912dca0c18807"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -462,15 +462,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -639,14 +639,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -727,15 +727,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "futures-intrusive"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
 dependencies = [
  "futures-core",
  "lock_api",
@@ -755,15 +755,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -772,21 +772,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -929,9 +929,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -1160,9 +1160,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1259,21 +1259,21 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1380,28 +1380,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1443,9 +1434,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.76"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -1456,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "overload"
@@ -1596,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plane-cli"
@@ -1724,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -1830,7 +1821,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.15",
+ "time 0.3.17",
  "yasna",
 ]
 
@@ -1845,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1865,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -2059,18 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2079,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -2133,7 +2124,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.15",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -2412,9 +2403,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2506,14 +2497,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2654,7 +2660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.15",
+ "time 0.3.17",
  "tracing-subscriber",
 ]
 
@@ -2720,7 +2726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.17",
  "tracing-core",
  "tracing-subscriber",
 ]
@@ -2760,7 +2766,7 @@ dependencies = [
  "radix_trie",
  "rand",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.17",
  "tokio",
  "tracing",
  "trust-dns-proto",
@@ -2825,7 +2831,7 @@ dependencies = [
  "futures-util",
  "serde",
  "thiserror",
- "time 0.3.15",
+ "time 0.3.17",
  "tokio",
  "toml",
  "tracing",
@@ -3248,7 +3254,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "time 0.3.15",
+ "time 0.3.17",
 ]
 
 [[package]]

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -27,10 +27,14 @@ impl Error for SchedulerError {}
 
 impl Scheduler {
     pub fn update_status(&self, timestamp: DateTime<Utc>, status: &DroneStatusMessage) {
-        self.last_status
+        if status.ready {
+            self.last_status
             .entry(status.cluster.clone())
             .or_default()
             .insert(status.drone_id.clone(), timestamp);
+        } else {
+            self.last_status.entry(status.cluster.clone()).or_default().remove(&status.drone_id);
+        }
     }
 
     pub fn schedule(

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -29,11 +29,14 @@ impl Scheduler {
     pub fn update_status(&self, timestamp: DateTime<Utc>, status: &DroneStatusMessage) {
         if status.ready {
             self.last_status
-            .entry(status.cluster.clone())
-            .or_default()
-            .insert(status.drone_id.clone(), timestamp);
+                .entry(status.cluster.clone())
+                .or_default()
+                .insert(status.drone_id.clone(), timestamp);
         } else {
-            self.last_status.entry(status.cluster.clone()).or_default().remove(&status.drone_id);
+            self.last_status
+                .entry(status.cluster.clone())
+                .or_default()
+                .remove(&status.drone_id);
         }
     }
 

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -88,12 +88,20 @@ impl TypedMessage for DrainDrone {
     type Response = ();
 
     fn subject(&self) -> String {
-        format!("cluster.{}.drone.{}.drain", self.cluster.subject_name(), self.drone.id())
+        format!(
+            "cluster.{}.drone.{}.drain",
+            self.cluster.subject_name(),
+            self.drone.id()
+        )
     }
 }
 
 impl DrainDrone {
     pub fn subscribe_subject(drone: DroneId, cluster: ClusterName) -> SubscribeSubject<Self> {
-        SubscribeSubject::new(format!("cluster.{}.drone.{}.drain", cluster.subject_name(), drone.id()))
+        SubscribeSubject::new(format!(
+            "cluster.{}.drone.{}.drain",
+            cluster.subject_name(),
+            drone.id()
+        ))
     }
 }

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -83,6 +83,7 @@ impl ScheduleRequest {
 pub struct DrainDrone {
     pub drone: DroneId,
     pub cluster: ClusterName,
+    pub drain: bool,
 }
 
 impl TypedMessage for DrainDrone {

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -77,3 +77,23 @@ impl ScheduleRequest {
         SubscribeSubject::new("cluster.*.schedule".into())
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct DrainDrone {
+    pub drone: DroneId,
+    pub cluster: ClusterName,
+}
+
+impl TypedMessage for DrainDrone {
+    type Response = ();
+
+    fn subject(&self) -> String {
+        format!("cluster.{}.drone.{}.drain", self.cluster.subject_name(), self.drone.id())
+    }
+}
+
+impl DrainDrone {
+    pub fn subscribe_subject(drone: DroneId, cluster: ClusterName) -> SubscribeSubject<Self> {
+        SubscribeSubject::new(format!("cluster.{}.drone.{}.drain", cluster.subject_name(), drone.id()))
+    }
+}

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -78,6 +78,7 @@ impl ScheduleRequest {
     }
 }
 
+/// Message sent to a drone to tell it to start draining.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DrainDrone {
     pub drone: DroneId,

--- a/dev/src/timeout.rs
+++ b/dev/src/timeout.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use futures::FutureExt;
 use std::{
     fmt::{Debug, Display},
@@ -52,14 +52,14 @@ impl Display for HumanDuration {
 /// This returns a future which must be awaited. If you want to put a
 /// timeout on a future that runs “in the background” without being awaited,
 /// use [spawn_timeout].
-pub async fn timeout<F, T>(timeout_ms: u64, message: &str, future: F) -> T
+pub async fn timeout<F, T>(timeout_ms: u64, message: &str, future: F) -> Result<T>
 where
     F: Future<Output = T>,
 {
     let start_time = SystemTime::now();
     let result = match tokio::time::timeout(Duration::from_millis(timeout_ms), future).await {
         Ok(t) => t,
-        Err(_) => panic!("{} timed out after {}ms", message, timeout_ms),
+        Err(_) => return Err(anyhow!("{} timed out after {}ms", message, timeout_ms)),
     };
     let elapsed = SystemTime::now().duration_since(start_time).unwrap();
 
@@ -70,7 +70,7 @@ where
         "Successfully executed future before timeout."
     );
 
-    result
+    Ok(result)
 }
 
 #[must_use]

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -7,6 +7,7 @@ use plane_core::{
             DroneStatusMessage, SpawnRequest, TerminationRequest,
         },
         dns::{DnsRecordType, SetDnsRecord},
+        scheduler::DrainDrone,
     },
     nats::{TypedNats, TypedSubscription},
     types::{BackendId, ClusterName, DroneId},
@@ -87,7 +88,7 @@ impl MockController {
             "Should receive DNS message.",
             self.dns_subscription.next(),
         )
-        .await
+        .await?
         .map(|d| d.value)
         .ok_or_else(|| anyhow!("Expected a DNS record."))
     }
@@ -104,7 +105,7 @@ impl MockController {
             "Should receive drone connect message.",
             self.drone_connect_response_subscription.next(),
         )
-        .await
+        .await?
         .unwrap();
 
         assert_eq!(ClusterName::new(CLUSTER_DOMAIN), message.value.cluster);
@@ -119,6 +120,7 @@ impl MockController {
         &self,
         drone_id: &DroneId,
         cluster: &ClusterName,
+        expect_ready: bool,
     ) -> Result<()> {
         let mut status_sub = self
             .nats
@@ -130,11 +132,12 @@ impl MockController {
             "Should receive status message from drone.",
             status_sub.next(),
         )
-        .await
+        .await?
         .unwrap();
 
         assert_eq!(drone_id, &message.value.drone_id);
         assert_eq!(cluster, &message.value.cluster);
+        assert_eq!(expect_ready, message.value.ready);
 
         Ok(())
     }
@@ -145,14 +148,14 @@ impl MockController {
             "Spawn request acknowledged by agent.",
             self.nats.request(request),
         )
-        .await?;
+        .await??;
 
         assert!(result, "Spawn request should result in response of _true_.");
         Ok(())
     }
 
     pub async fn terminate_backend(&self, request: &TerminationRequest) -> Result<()> {
-        let result = timeout(10_000, "Termination!", self.nats.request(request)).await?;
+        let result = timeout(10_000, "Termination!", self.nats.request(request)).await??;
 
         assert!(result, "Termination should result in response of _true_.");
         Ok(())
@@ -184,7 +187,7 @@ impl BackendStateSubscription {
                 &format!("State should become {:?}", expected_state),
                 self.sub.next()
             )
-            .await
+            .await?
             .unwrap()
             .value
             .state
@@ -234,13 +237,46 @@ async fn drone_sends_status_messages() -> Result<()> {
         .await?;
 
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
+        .await?;
+
+    Ok(())
+}
+
+#[integration_test]
+async fn drone_sends_draining_status() -> Result<()> {
+    let nats = Nats::new().await?;
+    let nats_connection = nats.connection().await?;
+    let mut controller_mock = MockController::new(nats_connection.clone()).await?;
+    let drone_id = DroneId::new_random();
+    let agent = Agent::new(&nats, &drone_id).await?;
+
+    controller_mock
+        .expect_handshake(&drone_id, agent.ip)
+        .await?;
+
+    controller_mock
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
+        .await?;
+
+    timeout(
+        1_000,
+        "Did not receive DrainDrone response",
+        nats_connection.request(&DrainDrone {
+            cluster: ClusterName::new(CLUSTER_DOMAIN),
+            drone: drone_id.clone(),
+        }),
+    )
+    .await??;
+
+    controller_mock
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), false)
         .await?;
 
     Ok(())
@@ -258,7 +294,7 @@ async fn spawn_with_agent() -> Result<()> {
         .await?;
 
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     let mut request = base_spawn_request();
@@ -325,7 +361,7 @@ async fn stats_are_acquired() -> Result<()> {
         .expect_handshake(&drone_id, agent.ip)
         .await?;
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     let mut request = base_spawn_request();
@@ -350,7 +386,7 @@ async fn stats_are_acquired() -> Result<()> {
         "Waiting for stats message.",
         stats_subscription.next(),
     )
-    .await
+    .await?
     .unwrap();
     assert!(stat.value.cpu_use_percent >= 0.);
     assert!(stat.value.mem_use_percent >= 0.);
@@ -385,7 +421,7 @@ async fn handle_error_during_start() -> Result<()> {
         .await?;
 
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     let mut request = base_spawn_request();
@@ -429,7 +465,7 @@ async fn handle_failure_after_ready() -> Result<()> {
         .await?;
 
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     let mut request = base_spawn_request();
@@ -472,7 +508,7 @@ async fn handle_successful_termination() -> Result<()> {
         .await?;
 
     controller_mock
-        .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     let mut request = base_spawn_request();
@@ -517,7 +553,7 @@ async fn handle_agent_restart() -> Result<()> {
             .await?;
 
         controller_mock
-            .expect_status_message(&drone_id, &ClusterName::new("plane.test"))
+            .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true)
             .await?;
 
         let mut request = base_spawn_request();
@@ -565,7 +601,7 @@ async fn handle_termination_request() -> Result<()> {
         .expect_handshake(&drone_id, agent.ip)
         .await?;
     controller_mock
-        .expect_status_message(&request.drone_id, &ClusterName::new("plane.test"))
+        .expect_status_message(&request.drone_id, &ClusterName::new("plane.test"), true)
         .await?;
 
     request.max_idle_secs = Duration::from_secs(1000);

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -271,6 +271,7 @@ async fn drone_sends_draining_status() -> Result<()> {
         nats_connection.request(&DrainDrone {
             cluster: ClusterName::new(CLUSTER_DOMAIN),
             drone: drone_id.clone(),
+            drain: true,
         }),
     )
     .await??;

--- a/dev/tests/cert.rs
+++ b/dev/tests/cert.rs
@@ -88,7 +88,7 @@ async fn cert_refresh() -> Result<()> {
             None,
         ),
     )
-    .await?;
+    .await??;
 
     assert_eq!(2, certs.len());
 
@@ -127,7 +127,7 @@ async fn cert_refresh_full() -> Result<()> {
             &pebble.client()?,
         ),
     )
-    .await?;
+    .await??;
 
     dns_handler.finish().await?;
 
@@ -158,7 +158,7 @@ async fn cert_refresh_eab() -> Result<()> {
             Some(&eab_keypair),
         ),
     )
-    .await?;
+    .await??;
 
     dns_handler.finish().await?;
 

--- a/drone/src/agent/backend.rs
+++ b/drone/src/agent/backend.rs
@@ -3,12 +3,13 @@ use std::{net::IpAddr, time::Duration};
 use super::docker::DockerInterface;
 use anyhow::{anyhow, Result};
 use plane_core::{
+    logging::LogError,
     messages::{
         agent::{BackendStatsMessage, DroneLogMessage},
         dns::{DnsRecordType, SetDnsRecord},
     },
     nats::TypedNats,
-    types::{BackendId, ClusterName}, logging::LogError,
+    types::{BackendId, ClusterName},
 };
 use tokio::{task::JoinHandle, time::sleep};
 use tokio_stream::StreamExt;
@@ -65,7 +66,8 @@ impl BackendMonitor {
                     name: backend_id.to_string(),
                     value: ip.to_string(),
                 })
-                .await.log_error("Error publishing DNS record.");
+                .await
+                .log_error("Error publishing DNS record.");
 
                 sleep(Duration::from_secs(SetDnsRecord::send_period())).await;
             }

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -164,6 +164,9 @@ pub async fn run_agent(agent_opts: AgentOptions) -> NeverResult {
 
     let (send_ready, recv_ready) = watch::channel(true);
 
+    // listen_for_drain is spawned separately from the tokio::select, because unlike the futures in that
+    // select, resolving does not indicate an error. listen_for_drain resolves when a node is told to drain,
+    // becaues it has no further purpose.
     tokio::spawn(listen_for_drain(
         nats.clone(),
         agent_opts.drone_id.clone(),

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -5,12 +5,13 @@ use http::Uri;
 use hyper::Client;
 use plane_core::{
     logging::LogError,
-    messages::agent::{DroneConnectRequest, DroneStatusMessage, SpawnRequest, TerminationRequest},
+    messages::{agent::{DroneConnectRequest, DroneStatusMessage, SpawnRequest, TerminationRequest}, scheduler::DrainDrone},
     nats::TypedNats,
     retry::do_with_retry,
     types::{ClusterName, DroneId},
     NeverResult,
 };
+use tokio::sync::watch::{self, Sender, Receiver};
 use std::{net::IpAddr, time::Duration};
 
 const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -90,21 +91,40 @@ async fn listen_for_termination_requests(executor: Executor, nats: TypedNats) ->
 }
 
 /// Repeatedly publish a status message advertising this drone as available.
-async fn ready_loop(nc: TypedNats, drone_id: &DroneId, cluster: ClusterName) -> NeverResult {
+async fn ready_loop(nc: TypedNats, drone_id: &DroneId, cluster: ClusterName, recv_ready: Receiver<bool>) -> NeverResult {
     let mut interval = tokio::time::interval(Duration::from_secs(4));
 
     loop {
+        let ready = *recv_ready.borrow();
         nc.publish_jetstream(&DroneStatusMessage {
             drone_id: drone_id.clone(),
             cluster: cluster.clone(),
             drone_version: PLANE_VERSION.to_string(),
-            ready: true,
+            ready,
         })
         .await
         .log_error("Error in ready loop.");
 
         interval.tick().await;
     }
+}
+
+/// Listen for drain instruction.
+async fn listen_for_drain(nc: TypedNats, drone_id: DroneId, cluster: ClusterName, send_ready: Sender<bool>) -> Result<()> {
+    let mut sub = nc
+        .subscribe(DrainDrone::subscribe_subject(drone_id, cluster))
+        .await?;
+
+    if let Some(req) = sub.next().await {
+        tracing::info!(req=?req.message(), "Received request to drain drone.");
+        req.respond(&()).await?;
+
+        send_ready.send(false).log_error("Error sending drain instruction.");
+    } else {
+        tracing::warn!("DrainDrone subscription ended.");
+    }
+    
+    Ok(())
 }
 
 pub async fn run_agent(agent_opts: AgentOptions) -> NeverResult {
@@ -126,9 +146,14 @@ pub async fn run_agent(agent_opts: AgentOptions) -> NeverResult {
     nats.publish(&request).await?;
 
     let executor = Executor::new(docker, db, nats.clone(), ip, cluster.clone());
+
+    let (send_ready, recv_ready) = watch::channel(true);
+
+    tokio::spawn(listen_for_drain(nats.clone(), agent_opts.drone_id.clone(), cluster.clone(), send_ready));
+
     tokio::select!(
-        result = ready_loop(nats.clone(), &agent_opts.drone_id, cluster.clone()) => result,
+        result = ready_loop(nats.clone(), &agent_opts.drone_id, cluster.clone(), recv_ready.clone()) => result,
         result = listen_for_spawn_requests(&agent_opts.drone_id, executor.clone(), nats.clone()) => result,
-        result = listen_for_termination_requests(executor.clone(), nats.clone()) => result
+        result = listen_for_termination_requests(executor.clone(), nats.clone()) => result,
     )
 }


### PR DESCRIPTION
This implements a basic version of drone draining.

- Adds a `DrainDrone` message type. The response of `DrainDrone` is a unit type (`()`), used to acknowledge that the message was received by the drone it was intended for.
- Adds a listener for `DrainDrone` messages to the agent.
- Adds a `watch` channel that the listener can use to send changes to the readiness value to the `ready_loop`.
- Removes drones from the scheduler's view when they indicate that they are not ready.

Additionally, I made some changes in order to test it:

- `timeout` returns a `Result<T>` instead of `T`, and returns an `Err()` instead of panicking.
- `expect_status_message` takes an additional argument which is asserted to be the readiness status of the drone.