### PR TITLE
Do not use sccache when S3 bucket url not set in $PLANE_SCCACHE_BUCKET (fixes slow docker build times when that variable is unset)

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -11,7 +11,9 @@ COPY . .
 #note: this is safe because build container is transitory
 ENV SCCACHE_BUCKET=$SCCACHE_BUCKET AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 
-RUN RUSTC_WRAPPER=/usr/local/bin/sccache cargo build --bin=plane-controller --release && sccache --show-stats
+RUN [ $SCCACHE_BUCKET ] \
+    && RUSTC_WRAPPER=/usr/local/bin/sccache cargo build --bin=plane-controller --release && sccache --show-stats \
+    || cargo build --bin=plane-controller --release 
 
 FROM gcr.io/distroless/cc-debian11
 

--- a/drone/Dockerfile
+++ b/drone/Dockerfile
@@ -11,7 +11,10 @@ COPY . .
 #note: this is safe because build container is transitory
 ENV SCCACHE_BUCKET=$SCCACHE_BUCKET AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 
-RUN RUSTC_WRAPPER=/usr/local/bin/sccache cargo build --bin=plane-drone --release && sccache --show-stats
+RUN [ $SCCACHE_BUCKET ] \
+    && RUSTC_WRAPPER=/usr/local/bin/sccache cargo build --bin=plane-drone --release && sccache --show-stats \
+    || cargo build --bin=plane-drone --release 
+
 
 FROM gcr.io/distroless/cc-debian11
 

--- a/drone/run_cached_iff_cache
+++ b/drone/run_cached_iff_cache
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-#if --var VARIABLE is not empty or undefined
-#then exec the COMMAND after --
-#else exec the normal command
-exec $@

--- a/drone/run_cached_iff_cache
+++ b/drone/run_cached_iff_cache
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+#if --var VARIABLE is not empty or undefined
+#then exec the COMMAND after --
+#else exec the normal command
+exec $@


### PR DESCRIPTION
this change just removes the use of sccache when $PLANE_SCCACHE_BUCKET is not set (its slow to not have this set as sccache makes http requests and waits for them to fail)