### PR TITLE
Use platform-agnostic watcher type

### DIFF
--- a/drone/src/proxy/certs.rs
+++ b/drone/src/proxy/certs.rs
@@ -2,7 +2,7 @@ use crate::keys::{load_certs, load_private_key, KeyCertPathPair};
 use anyhow::{Context, Result};
 use notify::{
     event::{AccessKind, AccessMode},
-    recommended_watcher, Event, EventKind, INotifyWatcher, RecursiveMode, Watcher,
+    recommended_watcher, Event, EventKind, RecursiveMode, Watcher, RecommendedWatcher,
 };
 use rustls::{
     server::ResolvesServerCert,
@@ -14,7 +14,7 @@ use tokio::sync::watch::{channel, Receiver, Sender};
 
 pub struct CertRefresher {
     receiver: Receiver<Option<Arc<CertifiedKey>>>,
-    _watcher: INotifyWatcher,
+    _watcher: RecommendedWatcher,
 }
 
 impl CertRefresher {


### PR DESCRIPTION
This allows the codebase to be compiled on `stable-aarch64-apple-darwin` (#254)