### PR TITLE
Assorted small fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/devcontainers/rust:1-bullseye
 
 USER vscode
 
+RUN git config --add push.autoSetupRemote true
+
 RUN rustup update stable
 
 RUN cargo install cargo-workspaces

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,18 @@ FROM mcr.microsoft.com/devcontainers/rust:1-bullseye
 
 USER vscode
 
+# Allow pushing directly to new branches.
 RUN git config --add push.autoSetupRemote true
 
+# Update Rust version to latest.
 RUN rustup update stable
 
+# Install NATS
+RUN curl -L https://github.com/nats-io/natscli/releases/download/v0.0.35/nats-0.0.35-amd64.deb -o nats.deb && dpkg -i nats.deb
+
+# Install cargo ws
 RUN cargo install cargo-workspaces
 
+# Install cargo nextest
 RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -52,8 +52,7 @@ Although Plane is primarily used via its NATS API, it also includes a small CLI 
 If you have Rust, you can build and install the CLI by running:
 
 ```bash
-cd cli
-cargo install --path=.
+cargo install --path=cli
 ```
 
 If you don't, or just want a temporary way to try out Plane, you can create a temporary alias that uses a pre-built Docker image of the cli:

--- a/drone/src/agent/engines/docker/util.rs
+++ b/drone/src/agent/engines/docker/util.rs
@@ -87,6 +87,8 @@ impl ContainerEvent {
         let action = event.action.as_deref()?;
         let actor = event.actor.as_ref()?;
         let name: String = actor.attributes.as_ref()?.get("name")?.to_string();
+        // Some actions add extra metadata after a colon, we strip that out.
+        let action = action.split(':').next().expect("First next() on split should never fail.");
 
         let event = match action {
             "attach" => ContainerEventType::Attach,

--- a/sample-config/compose/plane.yml
+++ b/sample-config/compose/plane.yml
@@ -42,7 +42,7 @@ services:
     container_name: plane-nats
     image: nats:latest
     command:
-      "--jetstream ${NATS_FLAGS}"
+      "--jetstream ${NATS_FLAGS:-}"
     ports:
       - "127.0.0.1:4222:4222"
     networks:


### PR DESCRIPTION
- Improve devenvironment
  - Add `autoSetupRemote` git configuration
  - Add NATS CLI
- Docs nit (remove unnecessary `cd`)
- Quiet logs a bit by removing unnecessary `Unhandled container action` messages
- Quiet warning about `NATS_FLAGS` being unset