### PR TITLE
Fix list-dns command (#258)

### DIFF
--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -263,7 +263,7 @@ fn nats_error_hack(
         Some(Err(err)) => {
             // If we update async_nats to a version that includes https://github.com/nats-io/nats.rs/pull/652, correct the typo below.
             if err.to_string()
-                == r#"eror while processing messages from the stream: 404, Some("No Messages")"#
+                == r#"error while processing messages from the stream: 404, Some("No Messages")"#
             {
                 return Ok(None);
             }


### PR DESCRIPTION
This fixes the bug in `list-dns`. Background on the bug:

- Until `async_nats` supports concrete error types, we have to match on the error message string to know when we've reached the end of a stream.
- When this was first implemented, there was a typo in the error string. I simultaneously submitted a PR to `async_nats` to fix the typo.
- My change to `async_nats` landed, but I didn't fix the typo on the Plane side, so the match case fell through.

This PR fixes the typo on the Plane side, and `plane-cli list-dns` now works for me.