### PR TITLE
Deduplicate drones in CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -148,12 +148,15 @@ async fn main() -> Result<()> {
             }
         }
         Command::ListDns => {
-            let results = nats
+            let mut results = nats
                 .get_all(
                     &SetDnsRecord::subscribe_subject(),
                     DeliverPolicy::LastPerSubject,
                 )
                 .await?;
+
+            results.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
+            results.dedup_by(|lhs, rhs| lhs.name == rhs.name);
 
             println!("Found {} DNS records:", results.len());
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,13 +84,15 @@ async fn main() -> Result<()> {
             }
         }
         Command::ListDrones => {
-            let drones = nats
+            let mut drones = nats
                 .get_all(
                     &DroneStatusMessage::subscribe_subject(),
                     DeliverPolicy::LastPerSubject,
                 )
                 .await?;
 
+            drones.sort_by(|lhs, rhs| lhs.drone_id.cmp(&rhs.drone_id));
+            drones.dedup_by(|lhs, rhs| lhs.drone_id == rhs.drone_id);
             println!("Found {} drones:", drones.len());
 
             for drone in drones {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 const RESOURCE_PREFIX: &str = "plane-";
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DroneId(String);
 
 impl Display for DroneId {


### PR DESCRIPTION
`get_all` works by fetching messages from a NATS consumer until it returns a specific error message. This means in the best case, there are two round-trips to NATS to fetch a list of messages. If a new message is received between the first and second round-trip on a subject that has already been sent, that message will be sent again.

Currently, `get_all` is only used by the cli. This adds deduplication in both locations that `get_all` is used, and also sorts the results.