### PR TITLE
State replication refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "time 0.3.17",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,6 +2949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,18 +1,14 @@
 use anyhow::Result;
-use async_nats::jetstream::consumer::DeliverPolicy;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use plane_core::{
     messages::{
-        agent::{
-            BackendStateMessage, DockerExecutableConfig, DroneStatusMessage, ResourceLimits,
-            TerminationRequest,
-        },
-        dns::SetDnsRecord,
+        agent::{BackendStateMessage, DockerExecutableConfig, ResourceLimits, TerminationRequest},
         scheduler::{DrainDrone, ScheduleRequest, ScheduleResponse},
     },
     nats_connection::NatsConnectionSpec,
     types::{BackendId, ClusterName, DroneId},
+    views::replica::SystemViewReplica,
 };
 use std::{collections::HashMap, time::Duration};
 
@@ -73,7 +69,7 @@ async fn main() -> Result<()> {
                 nats.subscribe_jetstream().await?
             };
 
-            while let Some(message) = sub.next().await {
+            while let Some((message, _)) = sub.next().await {
                 println!(
                     "{}\t{}\t{}",
                     message.backend.to_string().bright_cyan(),
@@ -83,23 +79,28 @@ async fn main() -> Result<()> {
             }
         }
         Command::ListDrones => {
-            let mut drones = nats
-                .get_all(
-                    &DroneStatusMessage::subscribe_subject(),
-                    DeliverPolicy::LastPerSubject,
-                )
-                .await?;
+            let sys = SystemViewReplica::snapshot(nats).await?;
 
-            drones.sort_by(|lhs, rhs| lhs.drone_id.cmp(&rhs.drone_id));
-            drones.dedup_by(|lhs, rhs| lhs.drone_id == rhs.drone_id);
-            println!("Found {} drones:", drones.len());
-
-            for drone in drones {
+            println!("Found {} clusters:", sys.clusters.len());
+            for (cluster_name, cluster) in sys.clusters {
                 println!(
-                    "{}\t{}",
-                    drone.drone_id.to_string().bright_green(),
-                    drone.cluster.to_string().bright_cyan()
+                    "Found {} drones in cluster {}:",
+                    cluster.drones.len(),
+                    cluster_name.hostname().bright_cyan()
                 );
+
+                for (drone_id, drone) in cluster.drones {
+                    println!(
+                        "{}\t{}\t{}",
+                        drone_id.to_string().bright_green(),
+                        cluster_name.to_string().bright_cyan(),
+                        drone
+                            .state()
+                            .map(|d| format!("{:?}", d))
+                            .unwrap_or_default()
+                            .bright_yellow(),
+                    );
+                }
             }
         }
         Command::Spawn {
@@ -147,26 +148,21 @@ async fn main() -> Result<()> {
             }
         }
         Command::ListDns => {
-            let mut results = nats
-                .get_all(
-                    &SetDnsRecord::subscribe_subject(),
-                    DeliverPolicy::LastPerSubject,
-                )
-                .await?;
+            let sys = SystemViewReplica::snapshot(nats).await?;
 
-            results.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
-            results.dedup_by(|lhs, rhs| lhs.name == rhs.name);
-
-            println!("Found {} DNS records:", results.len());
-
-            for result in results {
+            println!("Found {} clusters:", sys.clusters.len());
+            for (cluster_name, cluster) in sys.clusters {
                 println!(
-                    "{}.{}\t{}\t{}",
-                    result.name.to_string().bright_magenta(),
-                    result.cluster.to_string().bright_blue(),
-                    result.kind.to_string().bright_cyan(),
-                    result.value.to_string().bold()
+                    "Found {} live routes in cluster {}:",
+                    cluster.routes.len(),
+                    cluster_name.hostname().bright_cyan()
                 );
+
+                for backend in cluster.routes.keys() {
+                    if let Some(route) = cluster.route(backend) {
+                        println!("{}.{}\t{}", backend.id(), cluster_name.hostname(), route);
+                    }
+                }
             }
         }
         Command::Terminate {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,13 +65,12 @@ async fn main() -> Result<()> {
     match opts.command {
         Command::Status { backend } => {
             let mut sub = if let Some(backend) = backend {
-                nats.subscribe_jetstream(BackendStateMessage::subscribe_subject(&BackendId::new(
-                    backend,
-                )))
+                nats.subscribe_jetstream_subject(BackendStateMessage::subscribe_subject(
+                    &BackendId::new(backend),
+                ))
                 .await?
             } else {
-                nats.subscribe_jetstream(BackendStateMessage::wildcard_subject())
-                    .await?
+                nats.subscribe_jetstream().await?
             };
 
             while let Some(message) = sub.next().await {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,8 +36,8 @@ enum Command {
         backend: Option<String>,
     },
     Drain {
-        drone: String,
         cluster: String,
+        drone: String,
 
         /// Cancel draining and allow a drone to accept backends again.
         #[clap(long)]

--- a/controller/src/scheduler.rs
+++ b/controller/src/scheduler.rs
@@ -84,6 +84,8 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests {
+    use plane_core::messages::agent::DroneState;
+
     use super::*;
     const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -113,6 +115,7 @@ mod tests {
                 cluster: ClusterName::new("mycluster.test"),
                 drone_version: PLANE_VERSION.to_string(),
                 ready: true,
+                state: DroneState::Ready,
                 running_backends: None,
             },
         );
@@ -137,6 +140,7 @@ mod tests {
                 cluster: ClusterName::new("mycluster1.test"),
                 drone_version: PLANE_VERSION.to_string(),
                 ready: true,
+                state: DroneState::Ready,
                 running_backends: None,
             },
         );
@@ -161,6 +165,7 @@ mod tests {
                 cluster: ClusterName::new("mycluster.test"),
                 drone_version: PLANE_VERSION.to_string(),
                 ready: true,
+                state: DroneState::Ready,
                 running_backends: None,
             },
         );

--- a/controller/src/ttl_store/ttl_list.rs
+++ b/controller/src/ttl_store/ttl_list.rs
@@ -57,6 +57,7 @@ mod test {
     use crate::ttl_store::test::ts;
 
     #[test]
+    #[allow(clippy::needless_collect)]
     fn test_list() {
         let mut list: TtlList<u32> = TtlList::new(Duration::from_secs(10));
 

--- a/controller/src/ttl_store/ttl_multistore.rs
+++ b/controller/src/ttl_store/ttl_multistore.rs
@@ -35,6 +35,7 @@ mod test {
     use crate::ttl_store::test::ts;
 
     #[test]
+    #[allow(clippy::needless_collect)]
     fn test_multistore() {
         let mut store: TtlMultistore<u32, u32> = TtlMultistore::new(Duration::from_secs(10));
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1.36"
 tracing-stackdriver = "0.5.0"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 url = "2.2.2"
-uuid = { version = "1.1.2", features = ["v4"] }
+uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [features]
 bollard = ["dep:bollard"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ dashmap = "5.4.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 serde_with = "2.0.0"
+time = "0.3.17"
 tokio = "1.20.1"
 tokio-stream = "0.1.9"
 tracing = "0.1.36"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod nats_connection;
 pub mod retry;
 pub mod timing;
 pub mod types;
+pub mod views;
 
 /// This is a stand-in for the “never” type until RFC 1216 is stabilized.
 /// Because it is not constructable, the compiler enforces that a function

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -183,7 +183,7 @@ impl BackendStatsMessage {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum DroneState {
     /// The drone is starting and is not ready to spawn backends.
     Starting,

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -183,17 +183,46 @@ impl BackendStatsMessage {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+pub enum DroneState {
+    /// The drone is starting and is not ready to spawn backends.
+    Starting,
+
+    /// The drone is ready to spawn backends (subject to available capacity).
+    Ready,
+
+    /// The drone is running backends but is not accepting additional ones.
+    Draining,
+
+    /// The drone has finished draining and is ready to be shut down.
+    Drained,
+
+    /// The drone has shut down successfully.
+    Stopped,
+
+    /// The drone disappeared without a graceful shut-down and is assumed to be shut down.
+    Lost,
+}
+
+fn drone_state_ready() -> DroneState {
+    DroneState::Ready
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DroneStatusMessage {
     pub drone_id: DroneId,
     pub cluster: ClusterName,
     pub drone_version: String,
 
+    /// **DEPRECATED**. Will be removed in a future version of Plane.
     /// Indicates that a drone is ready to have backends scheduled to it.
     /// When a drone has been told to drain or is otherwise unable to have
     /// backends scheduled to it, this is set to false.
     #[serde(default = "default_ready")]
     pub ready: bool,
+
+    #[serde(default = "drone_state_ready")]
+    pub state: DroneState,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running_backends: Option<u32>,

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -510,6 +510,7 @@ impl BackendState {
 }
 
 /// An message representing a change in the state of a backend.
+/// **DEPRECATED**. Will be removed in a future version of Plane.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BackendStateMessage {
     /// The cluster the backend belongs to.

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -208,13 +208,13 @@ fn drone_state_ready() -> DroneState {
     DroneState::Ready
 }
 
+/// **DEPRECATED**. Will be removed in a future version of Plane.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DroneStatusMessage {
     pub drone_id: DroneId,
     pub cluster: ClusterName,
     pub drone_version: String,
 
-    /// **DEPRECATED**. Will be removed in a future version of Plane.
     /// Indicates that a drone is ready to have backends scheduled to it.
     /// When a drone has been told to drain or is otherwise unable to have
     /// backends scheduled to it, this is set to false.

--- a/core/src/messages/dns.rs
+++ b/core/src/messages/dns.rs
@@ -21,6 +21,7 @@ impl Display for DnsRecordType {
     }
 }
 
+/// **DEPRECATED**. Will be removed in a future version of Plane.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SetDnsRecord {
     pub cluster: ClusterName,

--- a/core/src/messages/mod.rs
+++ b/core/src/messages/mod.rs
@@ -3,3 +3,4 @@ pub mod cert;
 pub mod dns;
 pub mod logging;
 pub mod scheduler;
+pub mod state;

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -64,10 +64,7 @@ impl JetStreamable for StateUpdate {
         async_nats::jetstream::stream::Config {
             name: Self::stream_name().into(),
             max_messages_per_subject: 1,
-            subjects: vec![
-                "cluster.*.drone.*.sm.>".into(),
-                "state_update.landmark".into(),
-            ],
+            subjects: vec!["cluster.*.drone.*.sm.>".into()],
             ..async_nats::jetstream::stream::Config::default()
         }
     }

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -1,0 +1,95 @@
+use super::agent::{BackendState, DroneState};
+use crate::{
+    nats::{JetStreamable, NoReply, TypedMessage},
+    types::{BackendId, ClusterName, DroneId},
+};
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use time::OffsetDateTime;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum StateUpdate {
+    /// A drone heartbeat, sent periodically as long as the drone is alive.
+    /// Also sent immediately when the state changes.
+    DroneStatus {
+        cluster: ClusterName,
+        drone: DroneId,
+
+        /// State for scheduling purposes.
+        state: DroneState,
+
+        /// Public IP of the drone.
+        ip: IpAddr,
+        drone_version: String,
+    },
+    /// A backend state change. Sent immediately when a backend state changes.
+    BackendStatus {
+        cluster: ClusterName,
+        drone: DroneId,
+        backend: BackendId,
+        state: BackendState,
+    },
+    /// A message sent by a consumer who thinks a drone may be dead. If the
+    /// message comes back and the last timestamp of the drone in question
+    /// is still the last heartbeat on record, the drone can be assumed dead.
+    MaybeDead {
+        cluster: ClusterName,
+        drone: DroneId,
+        last_timestamp: OffsetDateTime,
+    },
+}
+
+impl TypedMessage for StateUpdate {
+    type Response = NoReply;
+
+    fn subject(&self) -> String {
+        match self {
+            StateUpdate::DroneStatus { cluster, drone, .. } => format!(
+                "cluster.{}.drone.{}.sm.status",
+                cluster.subject_name(),
+                drone.id()
+            ),
+            StateUpdate::BackendStatus {
+                cluster,
+                drone,
+                backend,
+                ..
+            } => format!(
+                "cluster.{}.drone.{}.sm.backend.{}.status",
+                cluster.subject_name(),
+                drone.id(),
+                backend.id()
+            ),
+            StateUpdate::MaybeDead { cluster, drone, .. } => format!(
+                "cluster.{}.drone.{}.sm.dead",
+                cluster.subject_name(),
+                drone.id()
+            ),
+        }
+    }
+}
+
+impl JetStreamable for StateUpdate {
+    fn stream_name() -> &'static str {
+        "system_state"
+    }
+
+    fn config() -> async_nats::jetstream::stream::Config {
+        async_nats::jetstream::stream::Config {
+            name: Self::stream_name().into(),
+            max_messages_per_subject: 1,
+            subjects: vec!["cluster.*.drone.*.sm.>".into()],
+            ..async_nats::jetstream::stream::Config::default()
+        }
+    }
+}
+
+impl StateUpdate {
+    pub fn cluster(&self) -> &ClusterName {
+        match self {
+            StateUpdate::DroneStatus { cluster, .. } => cluster,
+            StateUpdate::BackendStatus { cluster, .. } => cluster,
+            StateUpdate::MaybeDead { cluster, .. } => cluster,
+        }
+    }
+}

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -64,7 +64,10 @@ impl JetStreamable for StateUpdate {
         async_nats::jetstream::stream::Config {
             name: Self::stream_name().into(),
             max_messages_per_subject: 1,
-            subjects: vec!["cluster.*.drone.*.sm.>".into(), "state_update.landmark".into()],
+            subjects: vec![
+                "cluster.*.drone.*.sm.>".into(),
+                "state_update.landmark".into(),
+            ],
             ..async_nats::jetstream::stream::Config::default()
         }
     }

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -4,7 +4,6 @@ use crate::{
     types::{BackendId, ClusterName, DroneId},
 };
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use std::net::IpAddr;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,15 +28,6 @@ pub enum StateUpdate {
         backend: BackendId,
         state: BackendState,
     },
-    Landmark {
-        uuid: uuid::Uuid,
-    }
-}
-
-impl StateUpdate {
-    pub fn landmark() -> StateUpdate {
-        Self::Landmark { uuid: Uuid::new_v4() }
-    }
 }
 
 impl TypedMessage for StateUpdate {
@@ -61,7 +51,6 @@ impl TypedMessage for StateUpdate {
                 drone.id(),
                 backend.id()
             ),
-            StateUpdate::Landmark { .. } => "state_update.landmark".into(),
         }
     }
 }
@@ -82,11 +71,10 @@ impl JetStreamable for StateUpdate {
 }
 
 impl StateUpdate {
-    pub fn cluster(&self) -> Option<&ClusterName> {
+    pub fn cluster(&self) -> &ClusterName {
         match self {
-            StateUpdate::DroneStatus { cluster, .. } => Some(cluster),
-            StateUpdate::BackendStatus { cluster, .. } => Some(cluster),
-            StateUpdate::Landmark { .. } => None,
+            StateUpdate::DroneStatus { cluster, .. } => cluster,
+            StateUpdate::BackendStatus { cluster, .. } => cluster,
         }
     }
 }

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -2,6 +2,7 @@
 //!
 //! These use serde to serialize data to/from JSON over nats into Rust types.
 
+use crate::logging::LogError;
 use anyhow::{anyhow, Result};
 use async_nats::jetstream;
 use async_nats::jetstream::consumer::push::Messages;
@@ -12,18 +13,36 @@ use async_nats::{Client, Message, Subscriber};
 use bytes::Bytes;
 use dashmap::DashSet;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::error::Error;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use time::OffsetDateTime;
 use tokio_stream::StreamExt;
-
-use crate::logging::LogError;
 
 /// Unconstructable type, used as a [TypedMessage::Response] to indicate that
 /// no response is allowed.
 #[derive(Serialize, Deserialize)]
 pub enum NoReply {}
+
+pub struct MessageMeta {
+    pub timestamp: OffsetDateTime,
+    pub pending: u64,
+    pub sequence: u64,
+}
+
+impl TryFrom<jetstream::Message> for MessageMeta {
+    type Error = anyhow::Error;
+
+    fn try_from(value: jetstream::Message) -> Result<Self, Self::Error> {
+        let info = value.info().to_anyhow()?;
+
+        Ok(MessageMeta {
+            timestamp: info.published,
+            pending: info.pending,
+            sequence: info.stream_sequence,
+        })
+    }
+}
 
 pub trait TypedMessage: Serialize + DeserializeOwned {
     type Response: Serialize + DeserializeOwned;
@@ -223,7 +242,7 @@ pub struct JetstreamSubscription<T: TypedMessage> {
 }
 
 impl<T: TypedMessage> JetstreamSubscription<T> {
-    pub async fn next(&mut self) -> Option<T> {
+    pub async fn next(&mut self) -> Option<(T, MessageMeta)> {
         loop {
             if let Some(message) = self.stream.next().await {
                 let message = match message {
@@ -238,8 +257,15 @@ impl<T: TypedMessage> JetstreamSubscription<T> {
                     .await
                     .log_error("Error acking jetstream message.");
                 let value: Result<T, _> = serde_json::from_slice(&message.payload);
+                let meta = match MessageMeta::try_from(message) {
+                    Ok(meta) => meta,
+                    Err(error) => {
+                        tracing::error!(?error, "Error parsing jetstream message metadata.");
+                        continue;
+                    }
+                };
                 match value {
-                    Ok(value) => return Some(value),
+                    Ok(value) => return Some((value, meta)),
                     Err(error) => {
                         tracing::error!(?error, "Error parsing jetstream message; message ignored.")
                     }
@@ -248,28 +274,6 @@ impl<T: TypedMessage> JetstreamSubscription<T> {
                 return None;
             }
         }
-    }
-}
-
-/// async_nats returns an Ok(Err(_)) when a stream is empty instead of None, this replaces that specific error
-/// with None.
-///
-/// This will not be necessary once async_nats has concrete error types, which is coming.
-fn nats_error_hack(
-    message_result: Option<Result<jetstream::Message, Box<dyn Error + Send + Sync>>>,
-) -> anyhow::Result<Option<jetstream::Message>> {
-    match message_result {
-        Some(Ok(v)) => Ok(Some(v)),
-        Some(Err(err)) => {
-            // If we update async_nats to a version that includes https://github.com/nats-io/nats.rs/pull/652, correct the typo below.
-            if err.to_string()
-                == r#"error while processing messages from the stream: 404, Some("No Messages")"#
-            {
-                return Ok(None);
-            }
-            Err(anyhow!("NATS Error: {:?}", err))
-        }
-        None => Ok(None),
     }
 }
 
@@ -328,50 +332,6 @@ impl TypedNats {
         Ok(())
     }
 
-    pub async fn get_all<T>(
-        &self,
-        subject: &SubscribeSubject<T>,
-        deliver_policy: DeliverPolicy,
-    ) -> Result<Vec<T>>
-    where
-        T: TypedMessage<Response = NoReply> + JetStreamable,
-    {
-        let _ = self.ensure_jetstream_exists::<T>().await;
-        let stream = self
-            .jetstream
-            .get_stream(T::stream_name())
-            .await
-            .to_anyhow()?;
-
-        let consumer = stream
-            .create_consumer(async_nats::jetstream::consumer::pull::Config {
-                deliver_policy,
-                filter_subject: subject.subject.clone(),
-                ..async_nats::jetstream::consumer::pull::Config::default()
-            })
-            .await
-            .to_anyhow()?;
-
-        let mut result: Vec<T> = Vec::new();
-
-        loop {
-            let mut messages = consumer.fetch().messages().await.to_anyhow()?;
-            let mut done = true;
-
-            while let Some(v) = nats_error_hack(messages.next().await)? {
-                done = false;
-
-                result.push(serde_json::from_slice(&v.payload)?);
-            }
-
-            if done {
-                break;
-            }
-        }
-
-        Ok(result)
-    }
-
     async fn subscribe_jetstream_impl<T: JetStreamable>(
         &self,
         subject: Option<SubscribeSubject<T>>,
@@ -415,9 +375,7 @@ impl TypedNats {
     }
 
     /// Returns an ORDERED stream of messages published to a nats jetstream.
-    pub async fn subscribe_jetstream<T: JetStreamable>(
-        &self,
-    ) -> Result<JetstreamSubscription<T>> {
+    pub async fn subscribe_jetstream<T: JetStreamable>(&self) -> Result<JetstreamSubscription<T>> {
         self.subscribe_jetstream_impl(None).await
     }
 
@@ -434,20 +392,25 @@ impl TypedNats {
         Ok(())
     }
 
-    pub async fn publish_jetstream<T>(&self, value: &T) -> Result<()>
+    pub async fn publish_jetstream<T>(&self, value: &T) -> Result<u64>
     where
         T: TypedMessage<Response = NoReply> + JetStreamable,
     {
         self.ensure_jetstream_exists::<T>().await?;
 
-        self.jetstream
+        let sequence = self
+            .jetstream
             .publish(
                 value.subject().clone(),
                 Bytes::from(serde_json::to_vec(value)?),
             )
             .await
-            .to_anyhow()?;
-        Ok(())
+            .to_anyhow()?
+            .await
+            .to_anyhow()?
+            .sequence;
+
+        Ok(sequence)
     }
 
     pub async fn request<T>(&self, value: &T) -> Result<T::Response>

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -238,7 +238,7 @@ impl<T: DeserializeOwned> DelayedReply<T> {
 
 pub struct JetstreamSubscription<T: TypedMessage> {
     stream: Messages,
-    
+
     /// True if this consumer has pending messages to be consumed.
     pub has_pending: bool,
     _ph: PhantomData<T>,
@@ -363,8 +363,6 @@ impl TypedNats {
             .to_anyhow()?;
 
         let stream: Messages = consumer.messages().await.to_anyhow()?;
-
-        
 
         Ok(JetstreamSubscription {
             stream,

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -31,7 +31,7 @@ impl DroneId {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct BackendId(String);
 
 impl Display for BackendId {
@@ -70,7 +70,7 @@ impl BackendId {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ClusterName(String);
 
 impl FromStr for ClusterName {

--- a/core/src/views/mod.rs
+++ b/core/src/views/mod.rs
@@ -1,8 +1,14 @@
 use crate::{
-    messages::{agent::{BackendState, DroneState}, state::StateUpdate},
+    messages::{
+        agent::{BackendState, DroneState},
+        state::StateUpdate,
+    },
     types::{BackendId, ClusterName, DroneId},
 };
-use std::{collections::{HashMap, BTreeMap}, net::IpAddr};
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::IpAddr,
+};
 use time::OffsetDateTime;
 
 pub mod replica;
@@ -74,9 +80,6 @@ impl ClusterView {
                     drone_view.backends.insert(backend, state);
                 }
             }
-            StateUpdate::Landmark { .. } => {
-                unreachable!("update_state should never be called on ClusterView with a Landmark.");
-            },
         }
     }
 
@@ -98,10 +101,9 @@ pub struct SystemView {
 
 impl SystemView {
     pub fn update_state(&mut self, update: StateUpdate, timestamp: OffsetDateTime) {
-        if let Some(cluster_name) = update.cluster() {
-            let cluster = self.clusters.entry(cluster_name.clone()).or_default();
-            cluster.update_state(update, timestamp);
-        }
+        let cluster_name = update.cluster();
+        let cluster = self.clusters.entry(cluster_name.clone()).or_default();
+        cluster.update_state(update, timestamp);
     }
 
     pub fn cluster(&self, cluster: &ClusterName) -> Option<&ClusterView> {

--- a/core/src/views/mod.rs
+++ b/core/src/views/mod.rs
@@ -1,51 +1,9 @@
 use crate::{
-    messages::agent::{BackendState, DroneState},
+    messages::{agent::{BackendState, DroneState}, state::StateUpdate},
     types::{BackendId, ClusterName, DroneId},
 };
 use std::{collections::HashMap, net::IpAddr};
 use time::OffsetDateTime;
-
-#[derive(Debug)]
-pub enum StateUpdate {
-    /// A drone heartbeat, sent periodically as long as the drone is alive.
-    /// Also sent immediately when the state changes.
-    DroneStatus {
-        cluster: ClusterName,
-        drone: DroneId,
-
-        /// State for scheduling purposes.
-        state: DroneState,
-
-        /// Public IP of the drone.
-        ip: IpAddr,
-        drone_version: String,
-    },
-    /// A backend state change. Sent immediately when a backend state changes.
-    BackendStatus {
-        cluster: ClusterName,
-        drone: DroneId,
-        backend: BackendId,
-        state: BackendState,
-    },
-    /// A message sent by a consumer who thinks a drone may be dead. If the
-    /// message comes back and the last timestamp of the drone in question
-    /// is still the last heartbeat on record, the drone can be assumed dead.
-    MaybeDead {
-        cluster: ClusterName,
-        drone: DroneId,
-        last_timestamp: OffsetDateTime,
-    },
-}
-
-impl StateUpdate {
-    fn cluster(&self) -> &ClusterName {
-        match self {
-            StateUpdate::DroneStatus { cluster, .. } => cluster,
-            StateUpdate::BackendStatus { cluster, .. } => cluster,
-            StateUpdate::MaybeDead { cluster, .. } => cluster,
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct DroneView {
@@ -54,6 +12,8 @@ pub struct DroneView {
     pub ip: Option<IpAddr>,
     pub version: Option<String>,
 
+    /// A map of backends relevant to scheduling or routing.
+    /// When backends terminate, they are removed from this map.
     pub backends: HashMap<BackendId, BackendState>,
 }
 
@@ -217,7 +177,7 @@ mod test {
             OffsetDateTime::UNIX_EPOCH,
         );
 
-        // Route will not work, because we have not yet seen
+        // Route will not work yet, because we have not yet seen
         // a drone status message from this drone.
         assert!(system
             .cluster(&cluster)

--- a/core/src/views/mod.rs
+++ b/core/src/views/mod.rs
@@ -1,0 +1,82 @@
+use crate::{
+    messages::agent::{BackendStateMessage, DroneState, DroneStatusMessage},
+    nats::TypedNats,
+    types::{BackendId, ClusterName, DroneId},
+    Never,
+};
+use anyhow::{anyhow, Result};
+use dashmap::DashMap;
+use time::OffsetDateTime;
+use std::{collections::HashMap, net::Ipv4Addr, sync::Arc};
+use tokio::task::JoinHandle;
+
+pub struct DroneView {
+    state: DroneState,
+}
+
+#[derive(Default)]
+pub struct ClusterView {
+    backends: HashMap<BackendId, (DroneId, Ipv4Addr)>,
+    drones: HashMap<DroneId, DroneView>,
+}
+
+impl ClusterView {
+    pub fn receive_drone_status(&mut self, status: &DroneStatusMessage) {
+        if status.state == DroneState::Stopped {
+            self.drones.remove(&status.drone_id);
+        } else {
+            self.drones.insert(status.drone_id, )
+        }
+        
+    }
+}
+
+#[derive(Default)]
+pub struct SystemView {
+    clusters: HashMap<ClusterName, ClusterView>,
+}
+
+impl SystemView {
+    pub fn receive_drone_status_message(&mut self, message: &DroneStatusMessage, timestamp: OffsetDateTime) -> Result<()> {
+        let cluster = self.clusters.entry(message.cluster.clone()).or_default();
+
+        cluster.receive_drone_status(message);
+
+        Ok(())
+    }
+
+    pub fn receive_backend_state_message(&mut self, message: &BackendStateMessage, timestamp: OffsetDateTime) -> Result<()> {
+        Ok(())
+    }
+
+    // pub fn new(nats: TypedNats) -> Self {
+    //     let clusters: Arc<DashMap<ClusterName, ClusterView>> = Default::default();
+
+    //     let handle = {
+    //         let clusters = clusters.clone();
+    //         tokio::spawn(async move {
+    //             let mut drone_status_sub = nats
+    //                 .subscribe_jetstream(DroneStatusMessage::subscribe_subject())
+    //                 .await?;
+    //             let mut backend_status_sub = nats
+    //                 .subscribe_jetstream(BackendStateMessage::wildcard_subject())
+    //                 .await?;
+
+    //             loop {
+    //                 tokio::select! {
+    //                     status = drone_status_sub.next() => {
+                            
+    //                     }
+    //                 }
+    //             }
+
+    //             Err::<Never, anyhow::Error>(anyhow::anyhow!("not implemented."))
+    //         })
+    //     };
+
+    //     SystemView {
+    //         clusters,
+    //         _handle: handle,
+    //     }
+    // }
+}

--- a/core/src/views/replica.rs
+++ b/core/src/views/replica.rs
@@ -1,0 +1,70 @@
+use super::SystemView;
+use crate::nats::JetstreamSubscription;
+use crate::{messages::state::StateUpdate, nats::TypedNats, NeverResult};
+use anyhow::{anyhow, Result};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
+use tokio::task::JoinHandle;
+
+pub struct SystemViewReplica {
+    view: Arc<RwLock<SystemView>>,
+    handle: JoinHandle<NeverResult>,
+}
+
+impl SystemViewReplica {
+    async fn snapshot_impl(nats: TypedNats) -> Result<(SystemView, JetstreamSubscription<StateUpdate>)> {
+        let mut view = SystemView::default();
+        let mut sub = nats.subscribe_jetstream::<StateUpdate>().await?;
+
+        // Toss a landmark into the stream to get its sequence number.
+        // When we see a sequence number at least as high as this, we
+        // know we have consumed everything up to the point of the landmark.
+        let landmark = StateUpdate::landmark();
+        let seq = nats.publish_jetstream(&landmark).await?;
+
+        while let Some((update, meta)) = sub.next().await {
+            view.update_state(update, meta.timestamp);
+
+            if meta.sequence >= seq {
+                // We've consumed everything up to our initial landmark.
+                break;
+            }
+        }
+
+        Ok((view, sub))
+    }
+
+    pub async fn snapshot(nats: TypedNats) -> Result<SystemView> {
+        Ok(Self::snapshot_impl(nats).await?.0)
+    }
+
+    pub async fn new(nats: TypedNats) -> Result<SystemViewReplica> {
+        let (view, mut sub) = Self::snapshot_impl(nats).await?;
+        let view = Arc::new(RwLock::new(view));
+
+        let handle = {
+            let view = view.clone();
+
+            tokio::spawn(async move {
+                while let Some((update, meta)) = sub.next().await {
+                    view.write()
+                        .expect("SystemView RwLock was poisoned.")
+                        .update_state(update, meta.timestamp);
+                }
+
+                Err(anyhow!("SystemViewReplica loop terminated unexpectedly."))
+            })
+        };
+
+        Ok(SystemViewReplica { view, handle })
+    }
+
+    pub fn view(&self) -> RwLockReadGuard<SystemView> {
+        self.view.read().expect("SystemView RwLock was poisoned.")
+    }
+}
+
+impl Drop for SystemViewReplica {
+    fn drop(&mut self) {
+        self.handle.abort()
+    }
+}

--- a/core/src/views/replica.rs
+++ b/core/src/views/replica.rs
@@ -11,19 +11,21 @@ pub struct SystemViewReplica {
 }
 
 impl SystemViewReplica {
-    async fn snapshot_impl(nats: TypedNats) -> Result<(SystemView, JetstreamSubscription<StateUpdate>)> {
+    async fn snapshot_impl(
+        nats: TypedNats,
+    ) -> Result<(SystemView, JetstreamSubscription<StateUpdate>)> {
         let mut view = SystemView::default();
         let mut sub = nats.subscribe_jetstream::<StateUpdate>().await?;
 
         if sub.has_pending {
             while let Some((update, meta)) = sub.next().await {
                 view.update_state(update, meta.timestamp);
-    
+
                 if !sub.has_pending {
                     break;
                 }
             }
-        }            
+        }
 
         Ok((view, sub))
     }

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -3,7 +3,7 @@ use integration_test::integration_test;
 use plane_controller::run_scheduler;
 use plane_core::{
     messages::{
-        agent::{DroneStatusMessage, SpawnRequest, DroneState},
+        agent::{DroneState, DroneStatusMessage, SpawnRequest},
         scheduler::ScheduleResponse,
     },
     nats::TypedNats,

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -3,7 +3,7 @@ use integration_test::integration_test;
 use plane_controller::run_scheduler;
 use plane_core::{
     messages::{
-        agent::{DroneStatusMessage, SpawnRequest},
+        agent::{DroneStatusMessage, SpawnRequest, DroneState},
         scheduler::ScheduleResponse,
     },
     nats::TypedNats,
@@ -105,6 +105,7 @@ async fn one_drone_available() {
             drone_id: drone_id.clone(),
             drone_version: PLANE_VERSION.to_string(),
             ready: true,
+            state: DroneState::Ready,
             running_backends: None,
         })
         .await
@@ -128,6 +129,7 @@ async fn drone_not_ready() {
             drone_id: drone_id.clone(),
             drone_version: PLANE_VERSION.to_string(),
             ready: false,
+            state: DroneState::Draining,
             running_backends: None,
         })
         .await
@@ -161,6 +163,7 @@ async fn drone_becomes_not_ready() {
             drone_id: drone_id.clone(),
             drone_version: PLANE_VERSION.to_string(),
             ready: true,
+            state: DroneState::Ready,
             running_backends: None,
         })
         .await
@@ -172,6 +175,7 @@ async fn drone_becomes_not_ready() {
             drone_id: drone_id.clone(),
             drone_version: PLANE_VERSION.to_string(),
             ready: false,
+            state: DroneState::Draining,
             running_backends: None,
         })
         .await

--- a/drone/src/agent/backend.rs
+++ b/drone/src/agent/backend.rs
@@ -70,11 +70,7 @@ impl BackendMonitor {
         })
     }
 
-    fn log_loop<E: Engine>(
-        backend_id: &BackendId,
-        engine: &E,
-        nc: &TypedNats,
-    ) -> JoinHandle<()> {
+    fn log_loop<E: Engine>(backend_id: &BackendId, engine: &E, nc: &TypedNats) -> JoinHandle<()> {
         let mut stream = engine.log_stream(backend_id);
         let nc = nc.clone();
         let backend_id = backend_id.clone();
@@ -83,18 +79,16 @@ impl BackendMonitor {
             tracing::info!(%backend_id, "Log recording loop started.");
 
             while let Some(v) = stream.next().await {
-                nc.publish(&v).await.log_error("Error publishing log message.");
+                nc.publish(&v)
+                    .await
+                    .log_error("Error publishing log message.");
             }
 
             tracing::info!(%backend_id, "Log loop terminated.");
         })
     }
 
-    fn stats_loop<E: Engine>(
-        backend_id: &BackendId,
-        engine: &E,
-        nc: &TypedNats,
-    ) -> JoinHandle<()> {
+    fn stats_loop<E: Engine>(backend_id: &BackendId, engine: &E, nc: &TypedNats) -> JoinHandle<()> {
         let mut stream = Box::pin(engine.stats_stream(backend_id));
         let nc = nc.clone();
         let backend_id = backend_id.clone();
@@ -103,7 +97,9 @@ impl BackendMonitor {
             tracing::info!(%backend_id, "Stats recording loop started.");
 
             while let Some(stats) = stream.next().await {
-                nc.publish(&stats).await.log_error("Error publishing stats message.");
+                nc.publish(&stats)
+                    .await
+                    .log_error("Error publishing stats message.");
             }
 
             tracing::info!(%backend_id, "Stats loop terminated.");

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -148,7 +148,7 @@ async fn listen_for_drain(
         req.respond(&()).await?;
 
         let state = if req.value.drain {
-            DroneState::Drained
+            DroneState::Draining
         } else {
             DroneState::Ready
         };

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -20,7 +20,10 @@ use plane_core::{
     types::{ClusterName, DroneId},
     NeverResult,
 };
-use std::{net::{SocketAddr, IpAddr}, time::Duration};
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 use tokio::sync::watch::{self, Receiver, Sender};
 
 const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -9,7 +9,7 @@ use hyper::Client;
 use plane_core::{
     logging::LogError,
     messages::{
-        agent::{DroneConnectRequest, DroneStatusMessage, SpawnRequest, TerminationRequest, DroneState},
+        agent::{DroneStatusMessage, SpawnRequest, TerminationRequest, DroneState},
         scheduler::DrainDrone,
     },
     nats::TypedNats,
@@ -170,14 +170,6 @@ pub async fn run_agent(agent_opts: AgentOptions) -> NeverResult {
     let db = agent_opts.db;
     let cluster = agent_opts.cluster_domain.clone();
     let ip = do_with_retry(|| agent_opts.ip.get_ip(), 10, Duration::from_secs(10)).await?;
-
-    let request = DroneConnectRequest {
-        drone_id: agent_opts.drone_id.clone(),
-        cluster: cluster.clone(),
-        ip,
-    };
-
-    nats.publish(&request).await?;
 
     let executor = Executor::new(docker, db.clone(), nats.clone(), ip, cluster.clone());
 

--- a/drone/src/proxy/certs.rs
+++ b/drone/src/proxy/certs.rs
@@ -2,7 +2,7 @@ use crate::keys::{load_certs, load_private_key, KeyCertPathPair};
 use anyhow::{Context, Result};
 use notify::{
     event::{AccessKind, AccessMode},
-    recommended_watcher, Event, EventKind, RecursiveMode, Watcher, RecommendedWatcher,
+    recommended_watcher, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use rustls::{
     server::ResolvesServerCert,


### PR DESCRIPTION
Motivation, design, and broader plan discussed in #278.

This PR introduces a concept of a "view", which is a data structure that is synchronized so that it mirrors the state of the overall system.

`core/src/views/mod.rs` contains three views implemented in this PR, arranged as a three-level tree.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/46173/205110071-3f986df9-363c-46d7-bb1b-df9cff7707e3.png">

- `SystemView` represents the entire state of a multi-tenant system. 
- `ClusterView` represents the state of a cluster, consisting of a map from drone ID to `DroneView`, and from backend ID to the `DroneId` of the drone it is running on. The latter data structure is used for routing.
- `DroneView` represents the state of an individual drone, including the state of running backends.

The views themselves are not connected with the outside world. The only external mutator is `SystemView::update_state`, which takes a `StateUpdate` message and updates itself, dispatching down the tree as appropriate.

`UpdateState` messages are an `enum`, currently consisting of `BackendStatus` (to represent backend status changes), and `DroneStatus` (to represent drone heartbeats and status changes).

In addition to the views, a `SystemViewReplica` struct is implemented in `core/src/views/replica.rs`. This combines a (shared) instance of `SystemView` and a NATS subscription, and updates the shared instance when updates come in over NATS.

`SystemViewReplica` also provides a `snapshot` method, which is an `async` method that goes through the same initialization process of a `SystemViewReplica`, but stops as soon as it has an up-to-date version of all subjects and returns a `SystemView`. This `SystemView` is a frozen "snapshot" of the system state; the NATS subscription used to create it is dropped and no further updates are applied to it.

As of this PR, the controller does not yet use a `SystemView`; scheduling and DNS use the previous message patterns, which are preserved. But the drone has been modified to emit both the old message types and the new `UpdateState` messages, and the CLI has been rewritten to use the `SystemView` for `list-dns` and `list-drones` commands.