### PR TITLE
Add cluster to messages (prereq of #145 and #274)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plane-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "plane-controller"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "plane-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "plane-dev"
-version = "0.3.0"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "plane-drone"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "acme2-eab",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-cli"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-controller"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"
@@ -15,7 +15,7 @@ async-trait = "0.1.57"
 chrono = { version="0.4.22", default_features = false }
 clap = { version = "4.0.4", features = ["derive"] }
 dashmap = "5.3.4"
-plane-core = {path = "../core", version="0.3.0"}
+plane-core = {path = "../core", version="0.3.5"}
 futures = "0.3.24"
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-core"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -296,6 +296,8 @@ pub struct DockerExecutableConfig {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SpawnRequest {
+    pub cluster: Option<ClusterName>,
+
     pub drone_id: DroneId,
 
     /// The timeout after which the drone is shut down if no connections are made.
@@ -481,6 +483,9 @@ impl BackendState {
 /// An message representing a change in the state of a backend.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BackendStateMessage {
+    /// The cluster the backend belongs to.
+    pub cluster: Option<ClusterName>,
+
     /// The new state.
     pub state: BackendState,
 
@@ -526,8 +531,9 @@ impl BackendStateMessage {
 impl BackendStateMessage {
     /// Construct a status message using the current time as its timestamp.
     #[must_use]
-    pub fn new(state: BackendState, backend: BackendId) -> Self {
+    pub fn new(state: BackendState, cluster: Option<ClusterName>, backend: BackendId) -> Self {
         BackendStateMessage {
+            cluster,
             state,
             backend,
             time: Utc::now(),

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -43,6 +43,7 @@ impl ScheduleRequest {
         }
 
         SpawnRequest {
+            cluster: Some(self.cluster.clone()),
             drone_id: drone_id.clone(),
             backend_id,
             max_idle_secs: self.max_idle_secs,

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-dev"
-version = "0.3.0"
+version = "0.3.5"
 edition = "2021"
 publish = false
 

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -105,6 +105,7 @@ const TEST_IMAGE: &str = "ghcr.io/drifting-in-space/test-image:latest";
 
 pub fn base_spawn_request() -> SpawnRequest {
     SpawnRequest {
+        cluster: Some(ClusterName::new("plane.test")),
         backend_id: BackendId::new_random(),
         drone_id: DroneId::new_random(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-drone"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"
@@ -18,7 +18,7 @@ chrono = { version = "0.4.21", features = ["serde"], default_features=false }
 clap = { version = "4.0.4", features = ["derive"] }
 config = { version = "0.13.2", default_features = false, features = ["toml"] }
 dashmap = "5.3.4"
-plane-core = {path = "../core", version="0.3.0", features=["bollard"]}
+plane-core = {path = "../core", version="0.3.5", features=["bollard"]}
 futures = "0.3.24"
 http = "0.2.7"
 hyper = { version = "0.14.19", features = ["server", "client", "http1", "http2", "tcp"] }

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -135,6 +135,7 @@ impl<E: Engine> Executor<E> {
         self.nc
             .publish_jetstream(&BackendStateMessage::new(
                 BackendState::Loading,
+                spawn_request.cluster.clone(),
                 spawn_request.backend_id.clone(),
             ))
             .await
@@ -293,6 +294,7 @@ impl<E: Engine> Executor<E> {
         self.nc
             .publish_jetstream(&BackendStateMessage::new(
                 state,
+                spawn_request.cluster.clone(),
                 spawn_request.backend_id.clone(),
             ))
             .await


### PR DESCRIPTION
This will enable #145, but doesn't actually implement the schema change, because that will be a breaking change.

This is the first stage of a two-stage deploy. Once this version of Plane is rolled out to all drones and controllers, we can make the optional `cluster` fields non-optional.