### PR TITLE
Propagate errors that occur in image_exists

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -261,15 +261,15 @@ impl DroneConnectRequest {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub enum DockerPullPolicies {
+pub enum DockerPullPolicy {
     IfNotPresent,
     Always,
     Never,
 }
 
-impl Default for DockerPullPolicies {
+impl Default for DockerPullPolicy {
     fn default() -> Self {
-        DockerPullPolicies::IfNotPresent
+        DockerPullPolicy::IfNotPresent
     }
 }
 
@@ -289,8 +289,8 @@ pub struct DockerExecutableConfig {
     pub resource_limits: ResourceLimits,
 
     /// Pull policies, note: default is IfNotPresent
-    #[serde(default = "DockerPullPolicies::default")]
-    pub pull_policy: DockerPullPolicies,
+    #[serde(default = "DockerPullPolicy::default")]
+    pub pull_policy: DockerPullPolicy,
 }
 
 #[serde_as]

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -287,6 +287,7 @@ impl Engine for DockerInterface {
             }
             DockerPullPolicy::Never => false,
         };
+        tracing::info!(?should_pull_image, pull_policy=?spawn_request.executable.pull_policy, "Image pull decision made.");
 
         if should_pull_image {
             self.pull_image(

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -24,7 +24,7 @@ use bollard::{
 };
 use plane_core::{
     messages::agent::ResourceLimits,
-    messages::agent::{BackendStatsMessage, DockerPullPolicies, DroneLogMessage, SpawnRequest},
+    messages::agent::{BackendStatsMessage, DockerPullPolicy, DroneLogMessage, SpawnRequest},
     timing::Timer,
     types::BackendId,
 };
@@ -152,10 +152,13 @@ impl DockerInterface {
     }
 
     /// returns true if image exists, returns false in all other cases
-    pub async fn image_exists(&self, image: &str) -> bool {
+    pub async fn image_exists(&self, image: &str) -> Result<bool> {
         match self.docker.inspect_image(image).await {
-            Ok(..) => true,
-            Err(..) => false,
+            Ok(..) => Ok(true),
+            Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(false),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -278,11 +281,11 @@ impl Engine for DockerInterface {
 
     async fn load(&self, spawn_request: &SpawnRequest) -> Result<()> {
         let should_pull_image = match spawn_request.executable.pull_policy {
-            DockerPullPolicies::Always => true,
-            DockerPullPolicies::IfNotPresent => {
-                !self.image_exists(&spawn_request.executable.image).await
+            DockerPullPolicy::Always => true,
+            DockerPullPolicy::IfNotPresent => {
+                !self.image_exists(&spawn_request.executable.image).await?
             }
-            DockerPullPolicies::Never => false,
+            DockerPullPolicy::Never => false,
         };
 
         if should_pull_image {


### PR DESCRIPTION
Instead of treating all Docker errors as an image not existing, we should propagate non-404 errors.

This also renames `DockerPullPolicies` to `DockerPullPolicy` for consistency.