### PR TITLE
Fix --env so that it accepts multiple values

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,7 +34,7 @@ enum Command {
         #[clap(long, short)]
         port: Option<u16>,
         #[clap(long, short)]
-        env: Option<String>,
+        env: Vec<String>,
     },
     Status {
         backend: Option<String>,


### PR DESCRIPTION
This allows passing multiple values as `-e FOO1=BAR1 -e FOO2=BAR2`, etc. This was supposed to be the case all along; using `Option` was a bug.