### PR TITLE
Add passthrough flag for proxy

### DIFF
--- a/drone/src/config.rs
+++ b/drone/src/config.rs
@@ -2,7 +2,7 @@ use crate::{cert::acme::AcmeConfiguration, ip::IpSource, keys::KeyCertPathPair};
 use plane_core::{nats_connection::NatsConnectionSpec, types::DroneId};
 use serde::{Deserialize, Serialize};
 use std::{
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
 };
 
@@ -52,6 +52,8 @@ pub struct ProxyOptions {
     pub bind_ip: IpAddr,
     #[serde(default = "default_https_port")]
     pub https_port: u16,
+
+    pub passthrough: Option<SocketAddr>,
 }
 
 fn default_bind_address() -> IpAddr {

--- a/drone/src/plan.rs
+++ b/drone/src/plan.rs
@@ -51,6 +51,7 @@ impl DronePlan {
                 bind_ip: proxy_config.bind_ip,
                 bind_port: proxy_config.https_port,
                 key_pair: config.cert.clone(),
+                passthrough: proxy_config.passthrough,
             })
         } else {
             None

--- a/drone/src/proxy/mod.rs
+++ b/drone/src/proxy/mod.rs
@@ -21,6 +21,7 @@ pub struct ProxyOptions {
     pub bind_port: u16,
     pub key_pair: Option<KeyCertPathPair>,
     pub cluster_domain: String,
+    pub passthrough: Option<SocketAddr>,
 }
 
 async fn record_connections(
@@ -42,6 +43,7 @@ async fn run_server(options: ProxyOptions, connection_tracker: ConnectionTracker
         options.db,
         options.cluster_domain,
         connection_tracker.clone(),
+        options.passthrough,
     );
     let bind_address = SocketAddr::new(options.bind_ip, options.bind_port);
 


### PR DESCRIPTION
This adds a flag to the proxy to allow a "passthrough" `SocketAddr` used when a backend can't be resolved. _All_ unknown hosts will be proxied to this backend, but it will all be TLS terminated with the same certificate, so if this is used to resolve other hostnames a custom certificate will need to be passed in which covers all of them.

Only HTTP is supported for the upstream connection.

This will close #289.