### PR TITLE
Allow specifying docker user in drone config

### DIFF
--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -46,6 +46,7 @@ pub struct DockerInterface {
     docker: Docker,
     runtime: Option<String>,
     network: Option<String>,
+    user: Option<String>,
     gpu: bool,
 }
 
@@ -69,6 +70,7 @@ impl DockerInterface {
             runtime: config.runtime.clone(),
             network: config.network.clone(),
             gpu: config.insecure_gpu,
+            user: config.user.clone(),
         })
     }
 
@@ -198,6 +200,7 @@ impl DockerInterface {
 
             let config: Config<String> = Config {
                 image: Some(executable_config.image.to_string()),
+                user: self.user.clone(),
                 env: Some(env),
                 labels: Some(
                     vec![

--- a/drone/src/config.rs
+++ b/drone/src/config.rs
@@ -39,6 +39,10 @@ pub struct DockerConfig {
 
     #[serde(default)]
     pub insecure_gpu: bool,
+
+    /// The name or uid of the user to run backends as.
+    #[serde(default)]
+    pub user: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
This allows the docker user (equivalent to `docker --user`) to be specified when starting a drone. This allows us to ensure that containers are not run as `root`/uid 0.