### PR TITLE
Provide a way to pass a volume mount (#294)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -142,6 +142,7 @@ async fn main() -> Result<()> {
                         resource_limits: ResourceLimits::default(),
                         pull_policy: Default::default(),
                         port,
+                        volume_mounts: Vec::new(),
                     },
                     require_bearer_token: false,
                 })

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Error};
 use bollard::{container::LogOutput, container::Stats};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use serde_with::serde_as;
 use serde_with::DurationSeconds;
 use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
@@ -323,6 +324,11 @@ pub struct DockerExecutableConfig {
 
     /// Port to serve on. If this is not set, Plane uses port 8080.
     pub port: Option<u16>,
+
+    /// Volume mounts to add to the container.
+    /// Schema: https://pkg.go.dev/github.com/docker/docker@v20.10.22+incompatible/api/types/mount#Mount
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub volume_mounts: Vec<Value>,
 }
 
 #[serde_as]

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -161,19 +161,17 @@ where
     }
 
     pub async fn next(&mut self) -> Option<MessageWithResponseHandle<T>> {
-        loop {
-            if let Some(message) = self.subscription.next().await {
-                let result = MessageWithResponseHandle::new(message, self.nc.clone());
-                match result {
-                    Ok(v) => return Some(v),
-                    Err(error) => {
-                        tracing::error!(?error, "Error parsing message; message ignored.")
-                    }
+        while let Some(message) = self.subscription.next().await {
+            let result = MessageWithResponseHandle::new(message, self.nc.clone());
+            match result {
+                Ok(v) => return Some(v),
+                Err(error) => {
+                    tracing::error!(?error, "Error parsing message; message ignored.")
                 }
-            } else {
-                return None;
             }
         }
+
+        None
     }
 }
 

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -117,6 +117,7 @@ pub fn base_spawn_request() -> SpawnRequest {
             resource_limits: Default::default(),
             pull_policy: Default::default(),
             port: None,
+            volume_mounts: vec![],
         },
         bearer_token: None,
     }
@@ -135,6 +136,7 @@ pub fn base_scheduler_request() -> ScheduleRequest {
             resource_limits: Default::default(),
             pull_policy: Default::default(),
             port: None,
+            volume_mounts: vec![],
         },
         require_bearer_token: false,
     }

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -773,8 +773,7 @@ async fn attempt_to_spawn_with_allowed_volume_mount() {
     let mut request = base_spawn_request();
     request.drone_id = drone_id.clone();
     request.executable.volume_mounts = vec![json!({
-        "Type": "bind",
-        "Source": "/etc",
+        "Type": "tmpfs",
         "Target": "/bar",
     })];
 

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -22,6 +22,7 @@ use plane_dev::{
 };
 use plane_drone::config::DockerConfig;
 use plane_drone::{agent::AgentOptions, database::DroneDatabase, ip::IpSource};
+use serde_json::json;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 use tokio::time::{sleep, Instant};
@@ -36,7 +37,11 @@ struct Agent {
 }
 
 impl Agent {
-    pub async fn new(nats: &Nats, drone_id: &DroneId) -> Result<Agent> {
+    pub async fn new(
+        nats: &Nats,
+        drone_id: &DroneId,
+        docker_options: DockerConfig,
+    ) -> Result<Agent> {
         let ip = random_loopback_ip();
         let db = DroneDatabase::new(&scratch_dir("agent").join("drone.db")).await?;
 
@@ -46,7 +51,7 @@ impl Agent {
             nats: nats.connection().await?,
             cluster_domain: ClusterName::new(CLUSTER_DOMAIN),
             ip: IpSource::Literal(IpAddr::V4(ip)),
-            docker_options: DockerConfig::default(),
+            docker_options,
         };
 
         let agent_guard = expect_to_stay_alive(plane_drone::agent::run_agent(agent_opts));
@@ -233,7 +238,9 @@ async fn drone_sends_status_messages() {
         .await
         .unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
 
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
@@ -260,7 +267,9 @@ async fn drone_sends_draining_status() {
     let nats_connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(nats_connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
 
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
@@ -297,7 +306,9 @@ async fn spawn_with_agent() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
         .await
@@ -384,7 +395,9 @@ async fn stats_are_acquired() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
         .await
@@ -449,7 +462,9 @@ async fn handle_error_during_start() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
         .await
@@ -497,7 +512,9 @@ async fn handle_failure_after_ready() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
         .await
@@ -544,7 +561,9 @@ async fn handle_successful_termination() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
     controller_mock
         .expect_handshake(&drone_id, agent.ip)
         .await
@@ -593,7 +612,9 @@ async fn handle_agent_restart() {
 
     let mut state_subscription = {
         let drone_id = DroneId::new_random();
-        let agent = Agent::new(&nats_con, &drone_id).await.unwrap();
+        let agent = Agent::new(&nats_con, &drone_id, DockerConfig::default())
+            .await
+            .unwrap();
         controller_mock
             .expect_handshake(&drone_id, agent.ip)
             .await
@@ -621,7 +642,9 @@ async fn handle_agent_restart() {
     // Original agent goes away when it goes out of scope.
     {
         let drone_id = DroneId::new_random();
-        let agent = Agent::new(&nats_con, &drone_id).await.unwrap();
+        let agent = Agent::new(&nats_con, &drone_id, DockerConfig::default())
+            .await
+            .unwrap();
         controller_mock
             .expect_handshake(&drone_id, agent.ip)
             .await
@@ -640,7 +663,9 @@ async fn handle_termination_request() {
     let connection = nats.connection().await.unwrap();
     let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
     let drone_id = DroneId::new_random();
-    let agent = Agent::new(&nats, &drone_id).await.unwrap();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
 
     let mut request = base_spawn_request();
     // Ensure spawnee lives long enough to be terminated.
@@ -678,6 +703,103 @@ async fn handle_termination_request() {
 
     state_subscription
         .wait_for_state(BackendState::Terminated, 20_000)
+        .await
+        .unwrap();
+}
+
+#[integration_test]
+async fn attempt_to_spawn_with_disallowed_volume_mount() {
+    let nats = Nats::new().await.unwrap();
+    let connection = nats.connection().await.unwrap();
+    let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
+    let drone_id = DroneId::new_random();
+    let agent = Agent::new(&nats, &drone_id, DockerConfig::default())
+        .await
+        .unwrap();
+    controller_mock
+        .expect_handshake(&drone_id, agent.ip)
+        .await
+        .unwrap();
+
+    controller_mock
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true, 0)
+        .await
+        .unwrap();
+
+    let mut request = base_spawn_request();
+    request.drone_id = drone_id.clone();
+    request.executable.volume_mounts = vec![json!({
+        "source": "/foo",
+        "target": "/bar",
+    })];
+
+    let mut state_subscription = BackendStateSubscription::new(&connection, &request.backend_id)
+        .await
+        .unwrap();
+    controller_mock.spawn_backend(&request).await.unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::Loading, 5_000)
+        .await
+        .unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::ErrorLoading, 5_000)
+        .await
+        .unwrap();
+}
+
+#[integration_test]
+async fn attempt_to_spawn_with_allowed_volume_mount() {
+    let nats = Nats::new().await.unwrap();
+    let connection = nats.connection().await.unwrap();
+    let mut controller_mock = MockController::new(connection.clone()).await.unwrap();
+    let drone_id = DroneId::new_random();
+    let docker_config = DockerConfig {
+        allow_volume_mounts: true,
+        ..DockerConfig::default()
+    };
+    let agent = Agent::new(&nats, &drone_id, docker_config).await.unwrap();
+    controller_mock
+        .expect_handshake(&drone_id, agent.ip)
+        .await
+        .unwrap();
+
+    controller_mock
+        .expect_status_message(&drone_id, &ClusterName::new("plane.test"), true, 0)
+        .await
+        .unwrap();
+
+    let mut request = base_spawn_request();
+    request.drone_id = drone_id.clone();
+    request.executable.volume_mounts = vec![json!({
+        "Type": "bind",
+        "Source": "/etc",
+        "Target": "/bar",
+    })];
+
+    let mut state_subscription = BackendStateSubscription::new(&connection, &request.backend_id)
+        .await
+        .unwrap();
+    controller_mock.spawn_backend(&request).await.unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::Loading, 5_000)
+        .await
+        .unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::Starting, 5_000)
+        .await
+        .unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::Ready, 5_000)
+        .await
+        .unwrap();
+
+    state_subscription
+        .expect_backend_status_message(BackendState::Swept, 50_000)
         .await
         .unwrap();
 }

--- a/drone/src/config.rs
+++ b/drone/src/config.rs
@@ -39,6 +39,11 @@ pub struct DockerConfig {
 
     #[serde(default)]
     pub insecure_gpu: bool,
+
+    /// If true, spawn requests will be allowed to pass volume mounts on to
+    /// docker.
+    #[serde(default)]
+    pub allow_volume_mounts: bool,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
For maximum flexibility, I chose to simply pass the json value through. The advantage is that any possible volume configuration can be passed through; the disadvantage is that we don't check the schema until it arrives at the drone, so it's a bit tricker to debug. However, as a first pass, I think this is a step in the right direction.