### PR TITLE
Add cluster to message schemas

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -107,6 +107,7 @@ impl JetStreamable for DroneLogMessage {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BackendStatsMessage {
+    cluster: Option<ClusterName>,
     backend_id: BackendId,
     /// Fraction of maximum CPU.
     pub cpu_use_percent: f64,
@@ -132,6 +133,7 @@ impl BackendStatsMessage {
     #[cfg(feature = "bollard")]
     pub fn from_stats_messages(
         backend_id: &BackendId,
+        cluster: &ClusterName,
         prev_stats_message: &Stats,
         cur_stats_message: &Stats,
     ) -> Result<BackendStatsMessage, Error> {
@@ -179,6 +181,7 @@ impl BackendStatsMessage {
 
         Ok(BackendStatsMessage {
             backend_id: backend_id.clone(),
+            cluster: Some(cluster.clone()),
             cpu_use_percent,
             mem_use_percent,
         })

--- a/drone/src/agent/backend.rs
+++ b/drone/src/agent/backend.rs
@@ -34,7 +34,7 @@ impl BackendMonitor {
         nc: &TypedNats,
     ) -> Self {
         let log_loop = Self::log_loop(backend_id, engine, nc);
-        let stats_loop = Self::stats_loop(backend_id, engine, nc);
+        let stats_loop = Self::stats_loop(backend_id, cluster, engine, nc);
         let dns_loop = Self::dns_loop(backend_id, ip, nc, cluster);
 
         BackendMonitor {
@@ -88,8 +88,8 @@ impl BackendMonitor {
         })
     }
 
-    fn stats_loop<E: Engine>(backend_id: &BackendId, engine: &E, nc: &TypedNats) -> JoinHandle<()> {
-        let mut stream = Box::pin(engine.stats_stream(backend_id));
+    fn stats_loop<E: Engine>(backend_id: &BackendId, cluster: &ClusterName, engine: &E, nc: &TypedNats) -> JoinHandle<()> {
+        let mut stream = Box::pin(engine.stats_stream(backend_id, cluster));
         let nc = nc.clone();
         let backend_id = backend_id.clone();
 

--- a/drone/src/agent/engine.rs
+++ b/drone/src/agent/engine.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::Stream;
 use plane_core::{
     messages::agent::{BackendStatsMessage, DroneLogMessage, SpawnRequest},
-    types::BackendId,
+    types::{BackendId, ClusterName},
 };
 use std::{net::SocketAddr, pin::Pin};
 
@@ -51,5 +51,6 @@ pub trait Engine: Send + Sync + 'static {
     fn stats_stream(
         &self,
         backend: &BackendId,
+        cluster: &ClusterName,
     ) -> Pin<Box<dyn Stream<Item = BackendStatsMessage> + Send>>;
 }

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -29,7 +29,7 @@ use plane_core::{
         SpawnRequest,
     },
     timing::Timer,
-    types::BackendId,
+    types::{BackendId, ClusterName},
 };
 use std::time::Duration;
 use std::{net::SocketAddr, pin::Pin};
@@ -411,11 +411,12 @@ impl Engine for DockerInterface {
     fn stats_stream(
         &self,
         backend: &BackendId,
+        cluster: &ClusterName,
     ) -> Pin<Box<dyn Stream<Item = BackendStatsMessage> + Send>> {
         let stream = Box::pin(self.get_stats(backend));
         let backend = backend.clone();
 
-        Box::pin(StatsStream::new(backend, stream))
+        Box::pin(StatsStream::new(backend, cluster.clone(), stream))
     }
 
     async fn stop(&self, backend: &BackendId) -> Result<()> {


### PR DESCRIPTION
This adds a `cluster` field to all messages that cross the drone<>controller boundary.

Logs are an exception. For now, drones will be allowed to publish (but not subscribe) to `logs.drone.>`.

Planning doc: https://docs.google.com/document/d/1hXeucu2e5zuMD2f0Ft3K9wpRaJ8hp0zniFUK8s6HP9w/edit