### PR TITLE
Update bollard to crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af625ef0dd0ff8693b103b90ceaccdc258886ddb688671572f11df70d78684be"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hyper",
  "openssl",
  "reqwest",
@@ -71,7 +71,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2407f5e2adbf23226bbb3e20eaee46bfbf7b502a611bebb943641f85b3b5e94e"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "base64-url",
  "bytes",
  "futures",
@@ -143,12 +143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64-url"
 version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -183,10 +189,11 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.13.0"
-source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#659b9632878b6410b6c670d2854a0d93063e2cad"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af254ed2da4936ef73309e9597180558821cb16ae9bba4cb24ce6b612d8d80ed"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -200,6 +207,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_repr",
  "serde_urlencoded",
  "thiserror",
  "tokio",
@@ -210,8 +218,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.42.0-rc.6"
-source = "git+https://github.com/drifting-in-space/bollard.git?branch=paulgb/update-serde-with-version#659b9632878b6410b6c670d2854a0d93063e2cad"
+version = "1.42.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602bda35f33aeb571cef387dcd4042c643a8bf689d8aaac2cc47ea24cb7bc7e0"
 dependencies = [
  "serde",
  "serde_with",
@@ -1608,7 +1617,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1776,7 +1785,7 @@ dependencies = [
  "acme2-eab",
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bollard",
  "chrono",
  "clap",
@@ -1986,7 +1995,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2094,7 +2103,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2249,7 +2258,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
@@ -2994,7 +3003,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.61"
 async-nats = "0.24.0"
-bollard = {version = "0.13.0", optional=true, git="https://github.com/drifting-in-space/bollard.git", branch = "paulgb/update-serde-with-version"}
+bollard = {version = "0.14.0", optional=true}
 bytes = "1.2.1"
 chrono = { version = "0.4.22", features = ["serde", "clock"], default_features=false }
 clap = { version = "4.0.15", features = ["derive"] }

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.62"
 async-nats = "0.24.0"
-bollard = {version = "0.13.0", git="https://github.com/drifting-in-space/bollard.git", branch = "paulgb/update-serde-with-version"}
+bollard = "0.14.0"
 chrono = "0.4.22"
 plane-core = {path = "../core"}
 plane-drone = {path = "../drone"}

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 acme2-eab = "0.5.1"
 anyhow = "1.0.57"
 base64 = "0.13.0"
-bollard = {version = "0.13.0", git="https://github.com/drifting-in-space/bollard.git", branch = "paulgb/update-serde-with-version"}
+bollard = "0.14.0"
 chrono = { version = "0.4.21", features = ["serde"], default_features=false }
 clap = { version = "4.0.4", features = ["derive"] }
 config = { version = "0.13.2", default_features = false, features = ["toml"] }


### PR DESCRIPTION
We were using our own fork of bollard until our PR got merged and published. It has now been published.