### PR TITLE
Send duplicate messages to new and old NATS subjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plane-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "plane-controller"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "plane-core"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "plane-drone"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "acme2-eab",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -784,15 +784,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -812,15 +812,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -829,21 +829,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plane-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "plane-controller"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "plane-core"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "plane-drone"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "acme2-eab",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-cli"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-cli"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-controller"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-controller"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/controller/src/run.rs
+++ b/controller/src/run.rs
@@ -36,7 +36,7 @@ pub async fn update_backend_state_loop(nc: TypedNats) -> NeverResult {
             time: value.time,
         };
 
-        if let Err(e) = nc.publish_jetstream(&value).await {
+        if let Err(e) = nc.publish(&value).await {
             tracing::error!(error=%e, "Failed to publish backend state message.");
             continue;
         }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-core"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-core"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -51,6 +51,10 @@ impl TypedMessage for DroneLogMessage {
     fn subject(&self) -> String {
         format!("backend.{}.log", self.backend_id.id())
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
+    }
 }
 
 impl DroneLogMessage {
@@ -120,6 +124,14 @@ impl TypedMessage for BackendStatsMessage {
 
     fn subject(&self) -> String {
         format!("backend.{}.stats", self.backend_id.id())
+    }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        Some(format!(
+            "cluster.{}.backend.{}.stats",
+            self.cluster.as_ref().unwrap().subject_name(),
+            self.backend_id.id()
+        ))
     }
 }
 
@@ -243,6 +255,14 @@ impl TypedMessage for DroneStatusMessage {
     fn subject(&self) -> String {
         format!("drone.{}.status", self.drone_id.id())
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        Some(format!(
+            "cluster.{}.drone.{}.status",
+            self.cluster.subject_name(),
+            self.drone_id.id()
+        ))
+    }
 }
 
 impl JetStreamable for DroneStatusMessage {
@@ -285,6 +305,13 @@ impl TypedMessage for DroneConnectRequest {
 
     fn subject(&self) -> String {
         "drone.register".to_string()
+    }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        Some(format!(
+            "cluster.{}.drone.register",
+            self.cluster.subject_name()
+        ))
     }
 }
 
@@ -389,6 +416,16 @@ impl TypedMessage for SpawnRequest {
     fn subject(&self) -> String {
         format!("drone.{}.spawn", self.drone_id.id())
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        self.cluster.as_ref().map(|cluster| {
+            format!(
+                "cluster.{}.drone.{}.spawn",
+                cluster.subject_name(),
+                self.drone_id.id()
+            )
+        })
+    }
 }
 
 impl SpawnRequest {
@@ -413,6 +450,10 @@ impl TypedMessage for TerminationRequest {
             self.cluster_id.subject_name(),
             self.backend_id.id()
         )
+    }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
     }
 }
 
@@ -550,6 +591,10 @@ impl TypedMessage for UpdateBackendStateMessage {
             self.backend.id()
         )
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
+    }
 }
 
 impl UpdateBackendStateMessage {
@@ -609,6 +654,14 @@ impl TypedMessage for BackendStateMessage {
 
     fn subject(&self) -> String {
         format!("backend.{}.status", self.backend.id())
+    }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        Some(format!(
+            "cluster.{}.backend.{}.status",
+            self.cluster.as_ref().unwrap().subject_name(),
+            self.backend.id()
+        ))
     }
 }
 

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -18,6 +18,10 @@ impl TypedMessage for SetAcmeDnsRecord {
     fn subject(&self) -> String {
         "acme.set_dns_record".to_string()
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        Some(format!("cluster.{}.set_acme_record", self.cluster))
+    }
 }
 
 impl SetAcmeDnsRecord {

--- a/core/src/messages/dns.rs
+++ b/core/src/messages/dns.rs
@@ -36,6 +36,10 @@ impl TypedMessage for SetDnsRecord {
     fn subject(&self) -> String {
         format!("cluster.{}.dns.{}", self.cluster.subject_name(), self.kind)
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
+    }
 }
 
 impl JetStreamable for SetDnsRecord {

--- a/core/src/messages/logging.rs
+++ b/core/src/messages/logging.rs
@@ -59,6 +59,10 @@ impl TypedMessage for LogMessage {
             Component::Drone { drone_id } => format!("logs.drone.{}", drone_id.id()),
         }
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -80,6 +80,10 @@ impl TypedMessage for ScheduleRequest {
     fn subject(&self) -> String {
         format!("cluster.{}.schedule", self.cluster.subject_name())
     }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
+    }
 }
 
 impl ScheduleRequest {
@@ -105,6 +109,10 @@ impl TypedMessage for DrainDrone {
             self.cluster.subject_name(),
             self.drone.id()
         )
+    }
+
+    fn tmp_alt_subject(&self) -> Option<String> {
+        None
     }
 }
 

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-drone"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-drone"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 authors = ["Paul Butler <paul@driftingin.space>"]
 homepage = "https://plane.dev"


### PR DESCRIPTION
This is a step in the transition to a new NATS subject schema. Once we switch the controller to listen on the new subjects, the old subjects will be removed.