### PR TITLE
Consume new subjects (WIP)

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -137,7 +137,7 @@ impl TypedMessage for BackendStatsMessage {
 
 impl BackendStatsMessage {
     pub fn subscribe_subject(backend_id: &BackendId) -> SubscribeSubject<Self> {
-        SubscribeSubject::new(format!("backend.{}.stats", backend_id.id()))
+        SubscribeSubject::new(format!("cluster.*.backend.{}.stats", backend_id.id()))
     }
 }
 
@@ -318,7 +318,7 @@ impl TypedMessage for DroneConnectRequest {
 
 impl DroneConnectRequest {
     pub fn subscribe_subject() -> SubscribeSubject<Self> {
-        SubscribeSubject::new("drone.register".to_string())
+        SubscribeSubject::new("cluster.*.drone.register".to_string())
     }
 }
 
@@ -430,8 +430,8 @@ impl TypedMessage for SpawnRequest {
 }
 
 impl SpawnRequest {
-    pub fn subscribe_subject(drone_id: &DroneId) -> SubscribeSubject<Self> {
-        SubscribeSubject::new(format!("drone.{}.spawn", drone_id.id()))
+    pub fn subscribe_subject(cluster: &ClusterName, drone_id: &DroneId) -> SubscribeSubject<Self> {
+        SubscribeSubject::new(format!("cluster.{}.drone.{}.spawn", cluster.subject_name(), drone_id.id()))
     }
 }
 

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -26,6 +26,6 @@ impl TypedMessage for SetAcmeDnsRecord {
 
 impl SetAcmeDnsRecord {
     pub fn subscribe_subject() -> SubscribeSubject<Self> {
-        SubscribeSubject::new("acme.set_dns_record".to_string())
+        SubscribeSubject::new("cluster.*.set_dns_record".to_string())
     }
 }

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -28,7 +28,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 use tokio::time::{sleep, Instant};
 
-const CLUSTER_DOMAIN: &str = "plane.test";
+pub const CLUSTER_DOMAIN: &str = "plane.test";
 
 struct Agent {
     #[allow(unused)]

--- a/dev/tests/scheduler.rs
+++ b/dev/tests/scheduler.rs
@@ -21,6 +21,7 @@ use plane_dev::{
 use std::time::Duration;
 use tokio::time::sleep;
 
+pub const CLUSTER_DOMAIN: &str = "plane.test";
 const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 struct MockAgent {
@@ -39,9 +40,10 @@ impl MockAgent {
     ) -> Result<ScheduleResponse> {
         // Subscribe to spawn requests for this drone, to ensure that the
         // scheduler sends them.
+        let cluster = ClusterName::new(CLUSTER_DOMAIN);
         let mut sub = self
             .nats
-            .subscribe(SpawnRequest::subscribe_subject(drone_id))
+            .subscribe(SpawnRequest::subscribe_subject(&cluster, drone_id))
             .await?;
         sleep(Duration::from_millis(100)).await;
 

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -53,12 +53,13 @@ pub async fn wait_port_ready(addr: &SocketAddr) -> Result<()> {
 }
 
 async fn listen_for_spawn_requests(
+    cluster: &ClusterName,
     drone_id: &DroneId,
     executor: Executor<DockerInterface>,
     nats: TypedNats,
 ) -> NeverResult {
     let mut sub = nats
-        .subscribe(SpawnRequest::subscribe_subject(drone_id))
+        .subscribe(SpawnRequest::subscribe_subject(cluster, drone_id))
         .await?;
     executor.resume_backends().await?;
     tracing::info!("Listening for spawn requests.");
@@ -195,6 +196,7 @@ pub async fn run_agent(agent_opts: AgentOptions) -> NeverResult {
         ) => result,
 
         result = listen_for_spawn_requests(
+            &cluster,
             &agent_opts.drone_id,
             executor.clone(),
             nats.clone()


### PR DESCRIPTION
This is WIP because I realized that `DroneStatusMessage` will need to be split into two messages like `BackendStateMessage`, so I'm doing that first.