### PR TITLE
Add identity token option

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -15,6 +15,7 @@ use std::{collections::HashMap, net::IpAddr, str::FromStr, time::Duration};
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
 pub enum DockerCredentials {
     UsernamePassword { username: String, password: String },
+    IdentityToken { identity_token: String },
 }
 
 #[cfg(feature = "bollard")]
@@ -27,7 +28,13 @@ impl From<&DockerCredentials> for bollard::auth::DockerCredentials {
                     password: Some(password.clone()),
                     ..bollard::auth::DockerCredentials::default()
                 }
-            }
+            },
+            DockerCredentials::IdentityToken { identity_token } => {
+                bollard::auth::DockerCredentials {
+                    identitytoken: Some(identity_token.clone()),
+                    ..bollard::auth::DockerCredentials::default()
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
When using user/password credentials, Docker makes a round trip to an authentication server to obtain a JWT before pulling the image. The Docker API provides an alternative where we can provide this JWT directly. This PR exposes that option so that the spawner can avoid the round-trip if it already has an identity token.