### PR TITLE
Stop using 16 core workers

### DIFF
--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-controller-image.yml
+++ b/.github/workflows/build-controller-image.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-drone-image.yml
+++ b/.github/workflows/build-drone-image.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,6 @@ on:
 name: Clippy check
 jobs:
   clippy_check:
-    runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The github action is just kicking off a depot job anyway, so it doesn't need to be heavyweight.

I also removed it from the clippy one because we shouldn't need 16 cores just to run a linter.