### PR TITLE
Disable publishing to old subjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,6 @@ dependencies = [
  "clap",
  "config",
  "dashmap",
- "futures",
  "rand",
  "serde",
  "serde_json",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ chrono = { version = "0.4.22", features = ["serde", "clock"], default_features=f
 clap = { version = "4.0.15", features = ["derive"] }
 config = { version = "0.13.2", default_features = false, features = ["toml"] }
 dashmap = "5.4.0"
-futures = "0.3.26"
 rand = "0.8.5"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -58,10 +58,6 @@ impl TypedMessage for DroneLogMessage {
     fn subject(&self) -> String {
         format!("backend.{}.log", self.backend_id.id())
     }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
-    }
 }
 
 impl DroneLogMessage {
@@ -118,7 +114,7 @@ impl JetStreamable for DroneLogMessage {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BackendStatsMessage {
-    cluster: Option<ClusterName>,
+    cluster: ClusterName,
     backend_id: BackendId,
     /// Fraction of maximum CPU.
     pub cpu_use_percent: f64,
@@ -130,15 +126,11 @@ impl TypedMessage for BackendStatsMessage {
     type Response = NoReply;
 
     fn subject(&self) -> String {
-        format!("backend.{}.stats", self.backend_id.id())
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        Some(format!(
+        format!(
             "cluster.{}.backend.{}.stats",
-            self.cluster.as_ref().unwrap().subject_name(),
+            self.cluster.subject_name(),
             self.backend_id.id()
-        ))
+        )
     }
 }
 
@@ -201,7 +193,7 @@ impl BackendStatsMessage {
 
         Ok(BackendStatsMessage {
             backend_id: backend_id.clone(),
-            cluster: Some(cluster.clone()),
+            cluster: cluster.clone(),
             cpu_use_percent,
             mem_use_percent,
         })
@@ -261,15 +253,11 @@ impl TypedMessage for DroneStatusMessage {
     type Response = NoReply;
 
     fn subject(&self) -> String {
-        format!("drone.{}.status", self.drone_id.id())
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        Some(format!(
+        format!(
             "cluster.{}.drone.{}.status",
             self.cluster.subject_name(),
             self.drone_id.id()
-        ))
+        )
     }
 }
 
@@ -296,14 +284,10 @@ impl TypedMessage for DroneConnectRequest {
     type Response = NoReply;
 
     fn subject(&self) -> String {
-        "drone.register".to_string()
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        Some(format!(
+        format!(
             "cluster.{}.drone.register",
             self.cluster.subject_name()
-        ))
+        )
     }
 }
 
@@ -357,7 +341,7 @@ pub struct DockerExecutableConfig {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SpawnRequest {
-    pub cluster: Option<ClusterName>,
+    pub cluster: ClusterName,
 
     pub drone_id: DroneId,
 
@@ -406,17 +390,11 @@ impl TypedMessage for SpawnRequest {
     type Response = bool;
 
     fn subject(&self) -> String {
-        format!("drone.{}.spawn", self.drone_id.id())
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        self.cluster.as_ref().map(|cluster| {
-            format!(
-                "cluster.{}.drone.{}.spawn",
-                cluster.subject_name(),
-                self.drone_id.id()
-            )
-        })
+        format!(
+            "cluster.{}.drone.{}.spawn",
+            self.cluster.subject_name(),
+            self.drone_id.id()
+        )
     }
 }
 
@@ -442,10 +420,6 @@ impl TypedMessage for TerminationRequest {
             self.cluster_id.subject_name(),
             self.backend_id.id()
         )
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
     }
 }
 
@@ -583,10 +557,6 @@ impl TypedMessage for UpdateBackendStateMessage {
             self.backend.id()
         )
     }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
-    }
 }
 
 impl UpdateBackendStateMessage {
@@ -646,10 +616,6 @@ impl TypedMessage for BackendStateMessage {
 
     fn subject(&self) -> String {
         format!("backend.{}.status", self.backend.id())
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
     }
 }
 

--- a/core/src/messages/cert.rs
+++ b/core/src/messages/cert.rs
@@ -16,11 +16,7 @@ impl TypedMessage for SetAcmeDnsRecord {
     type Response = bool;
 
     fn subject(&self) -> String {
-        "acme.set_dns_record".to_string()
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        Some(format!("cluster.{}.set_acme_record", self.cluster.subject_name()))
+        format!("cluster.{}.set_acme_record", self.cluster.subject_name())
     }
 }
 

--- a/core/src/messages/dns.rs
+++ b/core/src/messages/dns.rs
@@ -36,10 +36,6 @@ impl TypedMessage for SetDnsRecord {
     fn subject(&self) -> String {
         format!("cluster.{}.dns.{}", self.cluster.subject_name(), self.kind)
     }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
-    }
 }
 
 impl JetStreamable for SetDnsRecord {

--- a/core/src/messages/logging.rs
+++ b/core/src/messages/logging.rs
@@ -59,10 +59,6 @@ impl TypedMessage for LogMessage {
             Component::Drone { drone_id } => format!("logs.drone.{}", drone_id.id()),
         }
     }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
-    }
 }
 
 #[cfg(test)]

--- a/core/src/messages/scheduler.rs
+++ b/core/src/messages/scheduler.rs
@@ -52,7 +52,7 @@ impl ScheduleRequest {
         };
 
         SpawnRequest {
-            cluster: Some(self.cluster.clone()),
+            cluster: self.cluster.clone(),
             drone_id: drone_id.clone(),
             backend_id,
             max_idle_secs: self.max_idle_secs,
@@ -80,10 +80,6 @@ impl TypedMessage for ScheduleRequest {
     fn subject(&self) -> String {
         format!("cluster.{}.schedule", self.cluster.subject_name())
     }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
-    }
 }
 
 impl ScheduleRequest {
@@ -109,10 +105,6 @@ impl TypedMessage for DrainDrone {
             self.cluster.subject_name(),
             self.drone.id()
         )
-    }
-
-    fn tmp_alt_subject(&self) -> Option<String> {
-        None
     }
 }
 

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -105,7 +105,7 @@ const TEST_IMAGE: &str = "ghcr.io/drifting-in-space/test-image:latest";
 
 pub fn base_spawn_request() -> SpawnRequest {
     SpawnRequest {
-        cluster: Some(ClusterName::new("plane.test")),
+        cluster: ClusterName::new("plane.test"),
         backend_id: BackendId::new_random(),
         drone_id: DroneId::new_random(),
         metadata: vec![("foo".into(), "bar".into())].into_iter().collect(),


### PR DESCRIPTION
Now that the latest version of Plane (controllers and drones) listen on the new subjects, we can make those the default and stop sending to the old subjects.