### PR TITLE
Add username/pass auth in Plane

### DIFF
--- a/core/src/nats_connection.rs
+++ b/core/src/nats_connection.rs
@@ -51,7 +51,9 @@ impl NatsConnectionSpec {
         let mut opts = match &self.auth {
             None => ConnectOptions::default(),
             Some(NatsAuthorization::Token { token }) => ConnectOptions::with_token(token.into()),
-            _ => todo!("Unsupported authentication."),
+            Some(NatsAuthorization::UserAndPassword { username, password }) => {
+                ConnectOptions::with_user_and_password(username.into(), password.into())
+            }
         };
 
         opts = opts.custom_inbox_prefix(inbox_prefix);


### PR DESCRIPTION
In NATS, we need to use user/pass auth if we want multiple sets of credentials. This enables that.