### PR TITLE
add BackendState::Lost

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use plane_core::{

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -463,6 +463,9 @@ pub enum BackendState {
     /// The container was terminated because all connections were closed.
     Swept,
 
+    /// The container was marked as lost.
+    Lost,
+
     /// The container was terminated through the API.
     Terminated,
 }
@@ -481,6 +484,7 @@ impl FromStr for BackendState {
             "Failed" => Ok(BackendState::Failed),
             "Exited" => Ok(BackendState::Exited),
             "Swept" => Ok(BackendState::Swept),
+            "Lost" => Ok(BackendState::Lost),
             "Terminated" => Ok(BackendState::Terminated),
             _ => Err(anyhow!(
                 "The string {:?} does not describe a valid state.",
@@ -502,6 +506,7 @@ impl ToString for BackendState {
             BackendState::Failed => "Failed".to_string(),
             BackendState::Exited => "Exited".to_string(),
             BackendState::Swept => "Swept".to_string(),
+            BackendState::Lost => "Lost".to_string(),
             BackendState::Terminated => "Terminated".to_string(),
         }
     }
@@ -519,6 +524,7 @@ impl BackendState {
                 | BackendState::Failed
                 | BackendState::Exited
                 | BackendState::Swept
+                | BackendState::Lost
                 | BackendState::Terminated
         )
     }

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -28,13 +28,13 @@ impl From<&DockerCredentials> for bollard::auth::DockerCredentials {
                     password: Some(password.clone()),
                     ..bollard::auth::DockerCredentials::default()
                 }
-            },
+            }
             DockerCredentials::IdentityToken { identity_token } => {
                 bollard::auth::DockerCredentials {
                     identitytoken: Some(identity_token.clone()),
                     ..bollard::auth::DockerCredentials::default()
                 }
-            },
+            }
         }
     }
 }
@@ -284,10 +284,7 @@ impl TypedMessage for DroneConnectRequest {
     type Response = NoReply;
 
     fn subject(&self) -> String {
-        format!(
-            "cluster.{}.drone.register",
-            self.cluster.subject_name()
-        )
+        format!("cluster.{}.drone.register", self.cluster.subject_name())
     }
 }
 
@@ -400,7 +397,11 @@ impl TypedMessage for SpawnRequest {
 
 impl SpawnRequest {
     pub fn subscribe_subject(cluster: &ClusterName, drone_id: &DroneId) -> SubscribeSubject<Self> {
-        SubscribeSubject::new(format!("cluster.{}.drone.{}.spawn", cluster.subject_name(), drone_id.id()))
+        SubscribeSubject::new(format!(
+            "cluster.{}.drone.{}.spawn",
+            cluster.subject_name(),
+            drone_id.id()
+        ))
     }
 }
 
@@ -451,7 +452,7 @@ pub enum BackendState {
     /// The container is listening on the expected port.
     Ready,
 
-    /// A timeout occurred becfore the container was ready.
+    /// A timeout occurred before the container was ready.
     TimedOutBeforeReady,
 
     /// The container exited on its own initiative with a non-zero status.

--- a/dev/src/lib.rs
+++ b/dev/src/lib.rs
@@ -109,9 +109,11 @@ where
         .block_on(future);
 
     TEST_CONTEXT.with(|cell| {
-        tokio::runtime::Runtime::new().expect("Failed to create runtime").block_on(async {
-            let context = cell.borrow_mut().take().expect("Test context not set.");
-            context.teardown().await;
-        })
+        tokio::runtime::Runtime::new()
+            .expect("Failed to create runtime")
+            .block_on(async {
+                let context = cell.borrow_mut().take().expect("Test context not set.");
+                context.teardown().await;
+            })
     });
 }

--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use integration_test::integration_test;
 use plane_controller::run::update_backend_state_loop;
 use plane_core::{

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -386,6 +386,7 @@ impl<E: Engine> Executor<E> {
             | BackendState::Failed
             | BackendState::Exited
             | BackendState::Swept
+            | BackendState::Lost
             | BackendState::Terminated => {
                 self.engine
                     .stop(&spawn_request.backend_id)


### PR DESCRIPTION
This adds a new backend state called "Lost". Right now, Plane does not directly set a backend's state to Lost. It is, instead, a state that is set by the operator of the Plane cluster mostly for semantic reasons.