### PR TITLE
Log backend exit code

### DIFF
--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -392,7 +392,8 @@ impl Engine for DockerInterface {
                 Some(_) => EngineBackendStatus::Failed,
             };
 
-            let state_json = serde_json::to_string(&state).ok();
+            let state_json = serde_json::to_string(&state)
+                .unwrap_or_else(|_| "Failed to serialize container state.".into());
 
             tracing::info!(?status, state=?state_json, "Set to terminal state.");
 

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -392,7 +392,9 @@ impl Engine for DockerInterface {
                 Some(_) => EngineBackendStatus::Failed,
             };
 
-            tracing::info!(?status, ?state.exit_code, "Set to terminal state.");
+            let state_json = serde_json::to_string(&state).ok();
+
+            tracing::info!(?status, state=?state_json, "Set to terminal state.");
 
             Ok(status)
         }

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -386,11 +386,15 @@ impl Engine for DockerInterface {
 
             Ok(EngineBackendStatus::Running { addr })
         } else {
-            match state.exit_code {
-                None => Ok(EngineBackendStatus::Terminated),
-                Some(0) => Ok(EngineBackendStatus::Exited),
-                Some(_) => Ok(EngineBackendStatus::Failed),
-            }
+            let status = match state.exit_code {
+                None => EngineBackendStatus::Terminated,
+                Some(0) => EngineBackendStatus::Exited,
+                Some(_) => EngineBackendStatus::Failed,
+            };
+
+            tracing::info!(?status, ?state.exit_code, "Set to terminal state.");
+
+            Ok(status)
         }
     }
 


### PR DESCRIPTION
We should expose this through the API as well but for now this is useful for debugging.