### PR TITLE
log backend termination failure

### DIFF
--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -97,7 +97,12 @@ async fn listen_for_termination_requests(
                 let executor = executor.clone();
 
                 req.respond(&()).await?;
-                tokio::spawn(async move { executor.kill_backend(&req.value).await });
+                tokio::spawn(async move {
+                    let result = executor.kill_backend(&req.value).await;
+                    if let Err(err) = result {
+                        tracing::warn!(?err, "Executor failed to kill backend.");
+                    }
+                });
             }
             None => return Err(anyhow!("Termination request subscription closed.")),
         }


### PR DESCRIPTION
If a backend termination request fails to find a backend to terminate, the Result is lost. This just makes sure we warn in the console if that happens.