### PR TITLE
Improve local development ergonomics for Plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 test-scratch
 lcov.info
+drone.sqlite3

--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@ Integration tests can be slow because they simulate entire workload lifecycles. 
 cargo install cargo-nextest
 cargo nextest run
 ```
+
+## Developing locally
+
+To develop locally, use the `./dev-*.sh` scripts in the root of this repo, in this order:
+
+- Start NATS with `./dev-nats.sh`
+- Start the controller with `./dev-controller.sh`
+- Start the drone with `./dev-drone.sh`
+
+Then, you can use the CLI with `./dev-cli.sh`. For example, you can spawn a hello-world image like this:
+
+    ./dev-cli.sh spawn plane.test ghcr.io/drifting-in-space/demo-image-hello-world:sha-3b58532
+
+And then access it with:
+
+    ./dev-curl.sh [URL returned after spawn]

--- a/controller/src/drone_state.rs
+++ b/controller/src/drone_state.rs
@@ -87,7 +87,6 @@ pub async fn apply_state_message(
     message: &WorldStateMessage,
 ) -> Result<Option<u64>> {
     let overwrite = message.overwrite();
-    tracing::info!(?message, ?overwrite, "Publishing state message.");
     if overwrite {
         nats.publish_jetstream(message).await.map(Some)
     } else {

--- a/controller/src/state/mod.rs
+++ b/controller/src/state/mod.rs
@@ -27,7 +27,6 @@ pub async fn start_state_loop(nc: TypedNats) -> Result<StateHandle> {
         let state_handle = state_handle.clone();
         tokio::spawn(async move {
             while let Some((message, _)) = sub.next().await {
-                tracing::info!(?message, "Applying state message");
                 state_handle.write_state().apply(message);
             }
         });

--- a/controller/src/state/world_state.rs
+++ b/controller/src/state/world_state.rs
@@ -32,8 +32,6 @@ impl StateHandle {
 
         let min_keepalive = timestamp - chrono::Duration::seconds(30);
 
-        tracing::info!(?world_state, "World state");
-
         Ok(world_state
             .cluster(cluster)
             .ok_or_else(|| anyhow!("Cluster not found."))?

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -159,6 +159,7 @@ impl BackendStatsMessage {
         cur_stats_message: &Stats,
     ) -> Result<BackendStatsMessage, Error> {
         // Based on docs here: https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerStats
+
         let mem_naive_usage = cur_stats_message
             .memory_stats
             .usage

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -156,8 +156,6 @@ where
             .context("Attempted to respond to a message with no reply subject.")?
             .to_string();
 
-        tracing::info!("Responding to message on {}", reply_inbox);
-
         self.nc
             .publish(reply_inbox, Bytes::from(serde_json::to_vec(response)?))
             .await?;

--- a/dev-cli.sh
+++ b/dev-cli.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo run -p plane-cli -- --nats=nats://127.0.0.1 "$@"

--- a/dev-controller.sh
+++ b/dev-controller.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo run -p plane-controller -- sample-config/dev-config/controller.toml

--- a/dev-curl.sh
+++ b/dev-curl.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+url=$1
+hostname=$(echo "$url" | awk -F[/:] '{print $4}')
+path=$(echo "$url" | awk -F[/:] '{for (i=5; i<=NF; i++) printf "/%s", $i}')
+
+curl -H "Host: ${hostname}" https://localhost:4333${path} --insecure -D -

--- a/dev-drone.sh
+++ b/dev-drone.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo run -p plane-drone -- sample-config/dev-config/drone.toml

--- a/dev-nats.sh
+++ b/dev-nats.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nats -js

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -391,7 +391,7 @@ impl Engine for DockerInterface {
             let state_json = serde_json::to_string(&state)
                 .unwrap_or_else(|_| "Failed to serialize container state.".into());
 
-            tracing::info!(?status, state=?state_json, "Set to terminal state.");
+            tracing::info!(?status, state=%state_json, "Set to terminal state.");
 
             Ok(status)
         }

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -280,7 +280,7 @@ impl<E: Engine> Executor<E> {
                 }
                 Ok(None) => {
                     // Successful termination.
-                    tracing::info!("Terminated successfully.");
+                    tracing::info!("Backend terminated successfully.");
                     break;
                 }
                 Err(error) => {

--- a/sample-config/dev-config/README.md
+++ b/sample-config/dev-config/README.md
@@ -1,0 +1,3 @@
+Plane configuration used by `dev-*.sh` scripts in the root of this repo.
+
+For annotated configuration examples, see `../plane-config` instead.

--- a/sample-config/dev-config/controller.toml
+++ b/sample-config/dev-config/controller.toml
@@ -1,0 +1,7 @@
+[nats]
+hosts = ["127.0.0.1"]
+
+[scheduler]
+
+[dns]
+port = 5353

--- a/sample-config/dev-config/drone.toml
+++ b/sample-config/dev-config/drone.toml
@@ -1,0 +1,16 @@
+cluster_domain = "plane.test"
+
+[nats]
+hosts = ["127.0.0.1"]
+
+[agent]
+ip = "127.0.0.1"
+
+[proxy]
+bind_ip = "127.0.0.1"
+port = "8080"
+https_port = "4333"
+
+[cert]
+key_path = "sample-config/auth/site-key.pem"
+cert_path = "sample-config/auth/site-cert.pem"

--- a/sample-config/plane-config/README.md
+++ b/sample-config/plane-config/README.md
@@ -1,0 +1,1 @@
+Sample config, also used for Docker compose.


### PR DESCRIPTION
This PR makes it easier to develop Plane locally.

It:
- Removes some of the more especially chatty logging. This is recently-introduced logging that is not load-bearing.
- Adds `./dev-*.sh` scripts to simplify common tasks.
- Adds Plane config files for running locally, including a `curl` wrapper.