### PR TITLE
Temporarily ignore drone with no meta

### DIFF
--- a/core/src/state/world_state.rs
+++ b/core/src/state/world_state.rs
@@ -39,7 +39,7 @@ impl StateHandle {
             .iter()
             .filter(|(_, drone)| {
                 drone.state() == Some(agent::DroneState::Ready)
-                    && drone.meta.is_some()
+                    // && drone.meta.is_some()
                     && drone.last_seen > Some(min_keepalive)
             })
             .map(|(drone_id, _)| drone_id.clone())


### PR DESCRIPTION
Meta is only populated when drones start, so if we require meta we can't schedule on existing drones.

This temporarily allows drones with no meta to be scheduled to. Once we've rolled drones and populated the state, we can uncomment this.