### PR TITLE
Remove signals dependency in favor of tokio::signals in Drone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,6 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
- "signal-hook",
  "sqlx",
  "tokio",
  "tokio-rustls 0.24.0",

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -316,7 +316,7 @@ impl<T: TypedMessage> JetstreamSubscription<T> {
                         continue;
                     }
                 };
-                
+
                 self.last_received_sequence = meta.sequence;
 
                 match value {
@@ -397,7 +397,7 @@ impl TypedNats {
         let stream_name = T::stream_name();
 
         let stream = self.jetstream.get_stream(stream_name).await.to_anyhow()?;
-        
+
         let init_sequence = stream.cached_info().state.last_sequence;
 
         let deliver_subject = self.nc.new_inbox();

--- a/drone/Cargo.toml
+++ b/drone/Cargo.toml
@@ -29,7 +29,6 @@ rustls = "0.21.0"
 rustls-pemfile = "1.0.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.81"
-signal-hook = "0.3.14"
 sqlx = { version = "0.6.1", features = [
     "runtime-tokio-rustls",
     "sqlite",
@@ -37,7 +36,7 @@ sqlx = { version = "0.6.1", features = [
     "macros",
     "offline",
 ] }
-tokio = { version = "1.18.2", features = ["rt"] }
+tokio = { version = "1.18.2", features = ["rt", "signal"] }
 tokio-rustls = "0.24.0"
 tokio-stream = "0.1.8"
 tracing = "0.1.36"

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -29,6 +29,7 @@ mod engine;
 mod engines;
 mod executor;
 
+#[derive(Clone)]
 pub struct AgentOptions {
     pub drone_id: DroneId,
     pub db: DroneDatabase,

--- a/drone/src/cert/acme.rs
+++ b/drone/src/cert/acme.rs
@@ -3,7 +3,7 @@ use base64::Engine;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct AcmeEabConfiguration {
     pub key_id: String,
 

--- a/drone/src/cert/mod.rs
+++ b/drone/src/cert/mod.rs
@@ -24,6 +24,7 @@ const DNS_01: &str = "dns-01";
 const REFRESH_MARGIN: Duration = Duration::from_secs(3600 * 24 * 15);
 const MAX_SLEEP: Duration = Duration::from_secs(3600);
 
+#[derive(Clone)]
 pub struct CertOptions {
     pub cluster_domain: String,
     pub nats: TypedNats,

--- a/drone/src/config.rs
+++ b/drone/src/config.rs
@@ -14,7 +14,7 @@ enum NatsAuthentication {
     // JWT
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum DockerConnection {
     Socket { socket: String },
@@ -29,7 +29,7 @@ impl Default for DockerConnection {
     }
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct DockerConfig {
     pub runtime: Option<String>,
 

--- a/drone/src/ip.rs
+++ b/drone/src/ip.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum IpSource {
     Literal(IpAddr),

--- a/drone/src/proxy/mod.rs
+++ b/drone/src/proxy/mod.rs
@@ -17,6 +17,7 @@ mod tls;
 
 pub const PLANE_AUTH_COOKIE: &str = "_plane_auth";
 
+#[derive(Clone)]
 pub struct ProxyOptions {
     pub db: DroneDatabase,
     pub bind_ip: IpAddr,

--- a/drone/src/run.rs
+++ b/drone/src/run.rs
@@ -72,7 +72,7 @@ async fn drone_main() -> Result<()> {
                 let proxy_options = proxy_options.clone();
                 let result = serve(proxy_options).await;
                 tracing::warn!(?result, "Proxy server exited.");
-            }            
+            }
         });
     }
 


### PR DESCRIPTION
This only impacts the drone; a follow-up will do the controller.