### PR TITLE
Simplify jetstream stream creation

### DIFF
--- a/core/src/messages/mod.rs
+++ b/core/src/messages/mod.rs
@@ -1,3 +1,5 @@
+use crate::nats::JetStreamable;
+use anyhow::anyhow;
 pub mod agent;
 pub mod cert;
 pub mod dns;
@@ -5,3 +7,27 @@ pub mod drone_state;
 pub mod logging;
 pub mod scheduler;
 pub mod state;
+
+async fn add_jetstream_stream<T: JetStreamable>(
+    jetstream: &async_nats::jetstream::Context,
+) -> anyhow::Result<()> {
+    let config = T::config();
+    tracing::debug!(name = config.name, "Creating jetstream stream.");
+    jetstream
+        .get_or_create_stream(config)
+        .await
+        .map_err(|d| anyhow!("Error: {d:?}"))?;
+
+    Ok(())
+}
+
+pub async fn initialize_jetstreams(
+    jetstream: &async_nats::jetstream::Context,
+) -> anyhow::Result<()> {
+    add_jetstream_stream::<state::WorldStateMessage>(jetstream).await?;
+    add_jetstream_stream::<agent::DroneLogMessage>(jetstream).await?;
+    add_jetstream_stream::<agent::BackendStateMessage>(jetstream).await?;
+    add_jetstream_stream::<dns::SetDnsRecord>(jetstream).await?;
+
+    Ok(())
+}

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -3,6 +3,7 @@
 //! These use serde to serialize data to/from JSON over nats into Rust types.
 
 use crate::logging::LogError;
+use crate::messages::initialize_jetstreams;
 use anyhow::{anyhow, Context, Result};
 use async_nats::jetstream;
 use async_nats::jetstream::consumer::push::Messages;
@@ -11,13 +12,10 @@ use async_nats::jetstream::context::Publish;
 use async_nats::jetstream::stream::Config;
 use async_nats::{Client, Message, Subscriber};
 use bytes::Bytes;
-use dashmap::DashSet;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
 use std::fmt::Debug;
 use std::future::Future;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::task::Poll;
 use time::OffsetDateTime;
 use tokio_stream::{Stream, StreamExt};
@@ -249,14 +247,6 @@ impl<T> NatsResultExt<T> for std::result::Result<T, async_nats::Error> {
 pub struct TypedNats {
     nc: Client,
     jetstream: jetstream::Context,
-    /// A set of JetStream names which have been created by this client.
-    /// JetStreams are lazily created by TypedNats the first time they
-    /// are used, and then stored here to avoid a round-trip after that.
-    /// Stream creation (with the same config) is idempotent, so it doesn't
-    /// matter if this is called multiple times, but we want to avoid
-    /// creating the same stream repeatedly because it costs a round-trip
-    /// to NATS.
-    jetstream_created_streams: Arc<DashSet<String>>,
 }
 
 pub struct DelayedReply<T: DeserializeOwned> {
@@ -316,7 +306,7 @@ impl<T: TypedMessage> JetstreamSubscription<T> {
                         continue;
                     }
                 };
-                
+
                 self.last_received_sequence = meta.sequence;
 
                 match value {
@@ -334,24 +324,12 @@ impl<T: TypedMessage> JetstreamSubscription<T> {
 
 impl TypedNats {
     #[must_use]
-    pub fn new(nc: Client) -> Self {
+    pub async fn new(nc: Client) -> Result<Self> {
         let jetstream = async_nats::jetstream::new(nc.clone());
-        TypedNats {
-            nc,
-            jetstream,
-            jetstream_created_streams: Arc::default(),
-        }
-    }
 
-    pub async fn ensure_jetstream_exists<T: JetStreamable>(&self) -> Result<()> {
-        if !self.jetstream_created_streams.contains(T::stream_name()) {
-            self.add_jetstream_stream::<T>().await?;
+        initialize_jetstreams(&jetstream).await?;
 
-            self.jetstream_created_streams
-                .insert(T::stream_name().to_string());
-        }
-
-        Ok(())
+        Ok(TypedNats { nc, jetstream })
     }
 
     /// Send a request that expects a reply, but return as soon as the request
@@ -376,28 +354,16 @@ impl TypedNats {
         })
     }
 
-    async fn add_jetstream_stream<T: JetStreamable>(&self) -> Result<()> {
-        let config = T::config();
-        tracing::debug!(name = config.name, "Creating jetstream stream.");
-        self.jetstream
-            .get_or_create_stream(config)
-            .await
-            .to_anyhow()?;
-
-        Ok(())
-    }
-
     async fn subscribe_jetstream_impl<T: JetStreamable>(
         &self,
         subject: Option<SubscribeSubject<T>>,
     ) -> Result<JetstreamSubscription<T>> {
         // An empty string is equivalent to no subject filter.
         let subject = subject.map(|d| d.subject).unwrap_or_default();
-        let _ = self.ensure_jetstream_exists::<T>().await;
         let stream_name = T::stream_name();
 
         let stream = self.jetstream.get_stream(stream_name).await.to_anyhow()?;
-        
+
         let init_sequence = stream.cached_info().state.last_sequence;
 
         let deliver_subject = self.nc.new_inbox();
@@ -457,8 +423,6 @@ impl TypedNats {
     where
         T: TypedMessage<Response = NoReply> + JetStreamable,
     {
-        self.ensure_jetstream_exists::<T>().await?;
-
         let sequence = self
             .jetstream
             .publish(
@@ -479,8 +443,6 @@ impl TypedNats {
     where
         T: TypedMessage<Response = NoReply> + JetStreamable,
     {
-        self.ensure_jetstream_exists::<T>().await?;
-
         let publish = Publish::build()
             .payload(Bytes::from(serde_json::to_vec(value)?))
             .expected_last_subject_sequence(0);

--- a/core/src/nats_connection.rs
+++ b/core/src/nats_connection.rs
@@ -77,7 +77,7 @@ impl NatsConnectionSpec {
         )
         .await?;
 
-        Ok(TypedNats::new(nats))
+        TypedNats::new(nats).await
     }
 
     pub async fn connect(&self, inbox_prefix: &str) -> Result<TypedNats> {
@@ -91,6 +91,6 @@ impl NatsConnectionSpec {
         )
         .await?;
 
-        Ok(TypedNats::new(nats))
+        TypedNats::new(nats).await
     }
 }


### PR DESCRIPTION
Previously, we created streams lazily the first time they were used. Since we are intentionally reducing the number of streams we use (likely down to 1), it's better just to construct them upfront.

Since there is a cost to creating streams, ideally we would do something fancy like attempt to read/write a stream, and create it only if the stream does not exist. But for now, this removes some cruft.