### PR TITLE
termination request now works if fired right after spawning

### DIFF
--- a/dev/tests/agent.rs
+++ b/dev/tests/agent.rs
@@ -701,25 +701,18 @@ async fn handle_termination_request() {
         .unwrap();
 
     let mut request = base_spawn_request().await;
-    // Ensure spawnee lives long enough to be terminated.
     request.drone_id = drone_id.clone();
-    request.max_idle_secs = Duration::from_secs(10_000);
 
     controller_mock
         .expect_status_message(&request.drone_id, &ClusterName::new("plane.test"), true, 0)
         .await
         .unwrap();
 
-    request.max_idle_secs = Duration::from_secs(1000);
     let mut state_subscription = BackendStateSubscription::new(&connection, &request.backend_id)
         .await
         .unwrap();
 
     controller_mock.spawn_backend(&request).await.unwrap();
-    state_subscription
-        .wait_for_state(BackendState::Ready, 20_000)
-        .await
-        .unwrap();
 
     let termination_request = TerminationRequest {
         backend_id: request.backend_id.clone(),

--- a/drone/src/agent/mod.rs
+++ b/drone/src/agent/mod.rs
@@ -74,6 +74,7 @@ async fn listen_for_spawn_requests(
 
                 req.respond(&true).await?;
                 tokio::spawn(async move {
+                    tracing::info!("spawning {:?}", &req.value.backend_id);
                     executor.start_backend(&req.value).await;
                 });
             }
@@ -99,6 +100,7 @@ async fn listen_for_termination_requests(
 
                 req.respond(&()).await?;
                 tokio::spawn(async move {
+                    tracing::info!("terminating {:?}", &req.value.backend_id);
                     let result = executor.kill_backend(&req.value).await;
                     if let Err(err) = result {
                         tracing::warn!(?err, "Executor failed to kill backend.");


### PR DESCRIPTION
so the problem was that awaiting the database insertion was taking a bit, and within that time the backend didn't exist in the hashtable.

I'd put this in the response to the spawnrequest, but then resumption would break so I just have creating the sigchannel as a preamble to run_backend. alternatively I could put it an Option I suppose

*mostly* fixes #336 , I say mostly because ofcourse it's possible for the thread to be preempted in such a way that the backend_listener is unset when the termination request's handler fires. to solve this, I want to somehow require that a backendContext is *required* to exist prior to run_backend, but I'll have to think about that.

In the meantime I don't think it's worthwhile to do some janky barrier stuff.