### PR TITLE
Remove assignment from backend message

### DIFF
--- a/controller/src/drone_state.rs
+++ b/controller/src/drone_state.rs
@@ -69,15 +69,6 @@ fn convert_to_state_message(
                     },
                 }),
             },
-            WorldStateMessage {
-                cluster: msg.cluster.clone(),
-                message: ClusterStateMessage::BackendMessage(BackendMessage {
-                    backend: msg.backend.clone(),
-                    message: BackendMessageType::Assignment {
-                        drone: msg.drone.clone(),
-                    },
-                }),
-            },
         ],
     }
 }
@@ -275,20 +266,10 @@ mod test {
                         timestamp: time,
                     },
                 }),
-            },
-            WorldStateMessage {
-                cluster: ClusterName::new("plane.test"),
-                message: ClusterStateMessage::BackendMessage(BackendMessage {
-                    backend: backend.clone(),
-                    message: BackendMessageType::Assignment {
-                        drone: drone.clone(),
-                    },
-                }),
-            },
+            }
         ];
 
         assert_eq!(state_message, expected);
         assert!(!state_message.first().unwrap().overwrite());
-        assert!(state_message.last().unwrap().overwrite());
     }
 }

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn run_scheduler(nats: TypedNats, state: StateHandle) -> NeverResult {
                             "Drone accepted backend."
                         );
 
-                        nats.publish(&WorldStateMessage {
+                        nats.publish_jetstream(&WorldStateMessage {
                             cluster: schedule_request.value.cluster.clone(),
                             message: ClusterStateMessage::BackendMessage(BackendMessage {
                                 backend: spawn_request.backend_id.clone(),


### PR DESCRIPTION
We had been redundantly emitting `Assignment` messages to ensure that backends existing at the time of the transition to the state machine were picked up. Now we don't need to because going forward the scheduler will emit an `Assignment` message for backends it schedules.