### PR TITLE
fix double termination

### DIFF
--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -272,6 +272,7 @@ impl<E: Engine> Executor<E> {
                                 continue;
                             },
                             Some(Signal::Terminate) => {
+								recv.close();
                                 break Ok(Some(BackendState::Terminated))
                             },
                             None => {

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -272,7 +272,7 @@ impl<E: Engine> Executor<E> {
                                 continue;
                             },
                             Some(Signal::Terminate) => {
-								recv.close();
+                                recv.close();
                                 break Ok(Some(BackendState::Terminated))
                             },
                             None => {


### PR DESCRIPTION
So the issue here is that for whatever reason after the terminate signal is received, another interrupt signal arrives as as consequence of the fact that the thing just got stopped. This then tries to terminate it again, which leads to an error.