### PR TITLE
Fix behavior of state initialization

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -26,7 +26,7 @@ pub async fn run_scheduler(nats: TypedNats, state: StateHandle) -> NeverResult {
     tracing::info!("Subscribed to spawn requests.");
 
     while let Some(schedule_request) = schedule_request_sub.next().await {
-        tracing::info!(spawn_request=?schedule_request.value, "Got spawn request");
+        tracing::info!(metadata=?schedule_request.value.metadata.clone(), "Got spawn request");
 
         if let Some(lock) = &schedule_request.value.lock {
             tracing::info!(lock=%lock, "Request includes lock.");


### PR DESCRIPTION
Previously, when we wanted a state snapshot (e.g. for `list-drones`), we would look at the sequence number of the state and read all messages up to that sequence number. This would work if we never deleted messages, but we only keep one message per subject, so it could happen that a message would come in after the snapshot sequence number which would mean that the client would never receive the new OR old value.

This changes the behavior to read until there are no more messages pending, which is the recommended way to do it. In conjunction with the nats-server update, this seems to work well.

I have also switched from logging the entire `SpawnRequest` to only logging the metadata.