### PR TITLE
Ignore connection timeout

### DIFF
--- a/drone/src/proxy/service.rs
+++ b/drone/src/proxy/service.rs
@@ -234,6 +234,9 @@ impl ProxyService {
                                     "Upgraded connection closed with UnexpectedEof."
                                 );
                             }
+                            Err(error) if error.kind() == ErrorKind::TimedOut => {
+                                tracing::info!(?duration, "Upgraded connection timed out.");
+                            }
                             Err(error) => {
                                 tracing::error!(
                                     ?duration,


### PR DESCRIPTION
Connections time out. It's just the cycle of life. We don't need to `ERROR` log it.