### PR TITLE
Don't schedule if a drone is missing IP information in the controller

### DIFF
--- a/core/src/state/world_state.rs
+++ b/core/src/state/world_state.rs
@@ -39,7 +39,7 @@ impl StateHandle {
             .iter()
             .filter(|(_, drone)| {
                 drone.state() == Some(agent::DroneState::Ready)
-                    // && drone.meta.is_some()
+                    && drone.meta.is_some()
                     && drone.last_seen > Some(min_keepalive)
             })
             .map(|(drone_id, _)| drone_id.clone())


### PR DESCRIPTION
This is an edge case that only comes up when the NATS data is dropped, but it's a good catch in case that happens (it does occasionally when I'm mucking with NATS on staging)