### PR TITLE
Set inactive threshold for NATS consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,12 +134,9 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 [[package]]
 name = "async-nats"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1174495e436c928905018f10a36160f7a8a6786450f50f4ce7fba05d1539704c"
+source = "git+https://github.com/nats-io/nats.rs.git?rev=261ead4#261ead4b244a03b246e766f6907dbf3497bcfe1d"
 dependencies = [
- "async-nats-tokio-rustls-deps",
- "base64 0.13.1",
- "base64-url",
+ "base64 0.21.2",
  "bytes",
  "futures",
  "http",
@@ -153,6 +150,7 @@ dependencies = [
  "ring",
  "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -161,19 +159,9 @@ dependencies = [
  "time",
  "tokio",
  "tokio-retry",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "async-nats-tokio-rustls-deps"
-version = "0.24.0-ALPHA.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdefe54cd7867d937c0a507d2a3a830af410044282cd3e4002b5b7860e1892e"
-dependencies = [
- "rustls 0.21.1",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -224,15 +212,6 @@ name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
-
-[[package]]
-name = "base64-url"
-version = "1.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "base64ct"
@@ -1466,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "nkeys"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e66a7cd1358277b2a6f77078e70aea7315ff2f20db969cc61153103ec162594"
+checksum = "c2d151f6ece2f3d1077f6c779268de2516653d8344ddde65addd785cce764fe5"
 dependencies = [
  "byteorder",
  "data-encoding",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.65"
-async-nats = "0.29.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs.git", rev = "261ead4" }
 clap = { version = "4.0.4", features = ["derive"] }
 colored = "2.0.0"
 plane-core = {path = "../core", version="0.3.0"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.61"
-async-nats = "0.29.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs.git", rev = "261ead4" }
 bollard = {version = "0.14.0", optional=true}
 bytes = "1.2.1"
 chrono = { version = "0.4.22", features = ["serde", "clock"], default_features=false }

--- a/core/nats-macros/Cargo.toml
+++ b/core/nats-macros/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-async-nats = "0.29.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs.git", rev = "261ead4" }
 darling = "0.20.1"
 proc-macro2 = "1.0.59"
 quote = "1.0.27"

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.62"
-async-nats = "0.29.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs.git", rev = "261ead4" }
 bollard = "0.14.0"
 chrono = { version="0.4.22", default_features = false }
 plane-core = {path = "../core"}

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-nats = "0.29.0"
+async-nats = { git = "https://github.com/nats-io/nats.rs.git", rev = "261ead4" }
 clap = { version = "4.2.7", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.83"


### PR DESCRIPTION
Updates the async-nats version and uses the new `inactive_threshold` parameter to keep the consumer alive for longer.