### PR TITLE
Make locks work with bearer tokens

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -216,7 +216,7 @@ async fn main() -> Result<()> {
                                     timestamp.to_string().bright_yellow()
                                 )
                             }
-                            BackendMessageType::Assignment { drone, lock } => {
+                            BackendMessageType::Assignment { drone, lock, .. } => {
                                 let mut text = format!(
                                     "is assigned to drone {}",
                                     drone.to_string().bright_yellow()

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -86,6 +86,7 @@ pub enum BackendMessageType {
     Assignment {
         drone: DroneId,
         lock: Option<String>,
+        bearer_token: Option<String>,
     },
     State {
         state: BackendState,

--- a/core/src/state/world_state.rs
+++ b/core/src/state/world_state.rs
@@ -179,13 +179,17 @@ impl DroneState {
 #[derive(Default, Debug)]
 pub struct BackendState {
     pub drone: Option<DroneId>,
+    pub bearer_token: Option<String>,
     pub states: BTreeSet<(chrono::DateTime<chrono::Utc>, agent::BackendState)>,
 }
 
 impl BackendState {
     fn apply(&mut self, message: BackendMessageType) {
         match message {
-            BackendMessageType::Assignment { drone, .. } => self.drone = Some(drone),
+            BackendMessageType::Assignment { drone, bearer_token, .. } => {
+                self.drone = Some(drone);
+                self.bearer_token = bearer_token;
+            },
             BackendMessageType::State {
                 state: status,
                 timestamp,
@@ -223,6 +227,7 @@ mod test {
             message: BackendMessageType::Assignment {
                 drone: DroneId::new("drone".into()),
                 lock: Some("mylock".into()),
+                bearer_token: None,
             },
         }));
 

--- a/dev/tests/dns.rs
+++ b/dev/tests/dns.rs
@@ -167,6 +167,7 @@ async fn dns_a_record() {
             message: BackendMessageType::Assignment {
                 drone: drone_id.clone(),
                 lock: None,
+                bearer_token: None,
             },
         }),
     });

--- a/dev/tests/drone_state.rs
+++ b/dev/tests/drone_state.rs
@@ -189,6 +189,7 @@ async fn status_lifecycle() {
                 message: BackendMessageType::Assignment {
                     drone: drone.clone(),
                     lock: None,
+                    bearer_token: None,
                 },
             }),
         },


### PR DESCRIPTION
If a backend has a bearer token and a lock, and we send a spawn request with the same lock, the returned result now includes the bearer token.

This works by attaching the bearer token to the drone assignment message.