### PR TITLE
Paul's suggestions on top of Abhi's remove sleeps PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,15 +99,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
@@ -289,6 +289,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "botan"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892c489ddae46dd4748fff8b41ad1fb17d405892fb6978ef470441eddb2df4ef"
+dependencies = [
+ "botan-sys",
+]
+
+[[package]]
+name = "botan-src"
+version = "0.21903.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb7bc6140fe563408b7ac7593897bbd589a284887a1d7a55f106df008a5d0a5"
+
+[[package]]
+name = "botan-sys"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8f94a43f34344aabf27d50838a2b38aa8aad7c7d1e941e8abb015f608c972b1"
+dependencies = [
+ "botan-src",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -347,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
@@ -426,16 +450,15 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.16.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
 dependencies = [
  "cookie",
  "idna 0.2.3",
  "log",
  "publicsuffix",
  "serde",
- "serde_derive",
  "serde_json",
  "time 0.3.22",
  "url",
@@ -1559,9 +1582,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1591,9 +1614,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -2006,10 +2029,11 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4954fbc00dcd4d8282c987710e50ba513d351400dbdd00e803a05172a90d8976"
+checksum = "450ee1cd6d9069b7941a235c06fa482d78a17ad0ba475dfceae5252b6bf7bdc9"
 dependencies = [
+ "botan",
  "pem",
  "ring",
  "time 0.3.22",
@@ -2921,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 serde_with = "3.0.0"
 time = "0.3.17"
-tokio = {version = "1.20.1", features = ["signal"]}
+tokio = { version = "1.20.1", features = ["signal", "sync"] }
 tokio-stream = "0.1.9"
 tracing = "0.1.36"
 tracing-stackdriver = "0.7.0"

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     nats::{JetstreamSubscription, TypedNats},
 };
 
-pub use self::world_state::{ClosableNotify, StateHandle, WorldState};
+pub use self::world_state::{StateHandle, WorldState};
 use anyhow::{anyhow, Result};
 
 mod world_state;

--- a/dev/src/util.rs
+++ b/dev/src/util.rs
@@ -175,7 +175,7 @@ pub async fn wait_for_predicate(
 ) {
     tokio::spawn(async move {
         loop {
-            let mut notify = {
+            let notify = {
                 let state = state.state();
                 let cur_logical_time = state.logical_time();
                 tracing::info!(?cur_logical_time, "waiting for predicate at time!");
@@ -183,9 +183,9 @@ pub async fn wait_for_predicate(
                     tracing::info!("predicate returned true!");
                     return;
                 }
-                state.get_listener(cur_logical_time + 1)
+                state.wait_for_seq(cur_logical_time + 1)
             };
-            notify.notified().await;
+            notify.await;
         }
     })
     .await


### PR DESCRIPTION
I suggest this as a simplification of the “remove sleeps” PR. The premise is still fundamentally the same, but I've made a few changes that eliminate the need for `CloseableNotify`. We still get a send + sync handle that we can pass around, namely a pinned and boxed future, which is nice because we can pass it to things that expect a future (like `timeout`) without having to convert it to a future first.

The fundamental problem with `Notify`, as I understand it, is that it is not attached to a queue or memory, so whether a listener gets notified depends on the order of events. Broadcast channels are a bit more heavyweight because they have a queue, but they are robust to different orderings.