### PR TITLE
Finishing touches on locks

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -188,7 +188,15 @@ async fn main() -> Result<()> {
                         format!("ACME TXT entry: {}", acme.value.to_string().bright_blue())
                     }
                     ClusterStateMessage::LockMessage(lock) => {
-                        format!("Lock : {:?}", lock.message)
+                        let lock_name = format!("{}", lock.lock);
+                        let uid = format!("{:x}", lock.uid);
+                        let lock_message = format!("{:?}", lock.message);
+                        format!(
+                            "Lock: {} (uid: {}) {}",
+                            lock_name.bright_cyan(),
+                            uid.bright_yellow(),
+                            lock_message.bright_magenta()
+                        )
                     }
                     ClusterStateMessage::DroneMessage(drone) => {
                         let DroneMessage { drone, message } = drone;
@@ -233,11 +241,22 @@ async fn main() -> Result<()> {
                                     timestamp.to_string().bright_yellow()
                                 )
                             }
-                            BackendMessageType::Assignment { drone, .. } => {
-                                let text = format!(
+                            BackendMessageType::Assignment { drone, lock_assignment, .. } => {
+                                let mut text = format!(
                                     "is assigned to drone {}",
                                     drone.to_string().bright_yellow()
                                 );
+
+                                if let Some(lock) = lock_assignment {
+                                    let lock_name = format!("{}", lock.lock);
+                                    let uid = format!("{:x}", lock.uid);
+                                    text.push_str(&format!(
+                                        " with lock {} (uid: {})",
+                                        lock_name.bright_cyan(),
+                                        uid.bright_yellow()
+                                    ));
+                                }
+
                                 text
                             }
                         };

--- a/core/src/messages/state.rs
+++ b/core/src/messages/state.rs
@@ -153,7 +153,7 @@ impl TypedMessage for WorldStateMessage {
 
     fn subject(&self) -> String {
         match &self {
-            WorldStateMessage::Heartbeat { .. } => "heartbeat".into(),
+            WorldStateMessage::Heartbeat { .. } => "state.heartbeat".into(),
             WorldStateMessage::ClusterMessage { message, cluster } => match message {
                 ClusterStateMessage::LockMessage(message) => match message.message {
                     ClusterLockMessageType::Announce => format!(

--- a/sample-config/dev-config/drone.toml
+++ b/sample-config/dev-config/drone.toml
@@ -8,7 +8,7 @@ ip = "127.0.0.1"
 
 [proxy]
 bind_ip = "127.0.0.1"
-port = "8080"
+http_port = "8080"
 https_port = "4333"
 
 [cert]


### PR DESCRIPTION
This adds a few changes to be merged on top of #427 that came up when testing. Mostly they have to do with the ergonomics of testing.

Changes:
- Made CLI logging for locks more verbose and added color.
- Log locks when an assignment includes one
- Change heartbeat message subject from `heartbeat` to `state.heartbeat` (the `plane_state` stream has the subject pattern `state.>`, so `heartbeat` does not match it.
- Update `port` to `http_port` in the sample `drone.toml` config.