### PR TITLE
Temporarily ignore assignment message subject mismatches

### DIFF
--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -124,7 +124,9 @@ fn parse_and_verify_message<T: TypedMessage>(message: &Message) -> Result<T> {
     let value: T = serde_json::from_slice(&message.payload)?;
     let expected_subject = value.subject();
     if expected_subject != message.subject {
-        if expected_subject.starts_with("state.cluster.") && expected_subject.ends_with(".assignment") {
+        if expected_subject.starts_with("state.cluster.")
+            && expected_subject.ends_with(".assignment")
+        {
             // Temporarily ignore due to subject renaming.
         } else {
             return Err(anyhow!(
@@ -132,7 +134,7 @@ fn parse_and_verify_message<T: TypedMessage>(message: &Message) -> Result<T> {
                 message.subject,
                 value.subject()
             ));
-        }        
+        }
     }
 
     Ok(value)

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -122,12 +122,17 @@ where
 /// expected subject for that message.
 fn parse_and_verify_message<T: TypedMessage>(message: &Message) -> Result<T> {
     let value: T = serde_json::from_slice(&message.payload)?;
-    if value.subject() != message.subject {
-        return Err(anyhow!(
-            "Message subject ({}) does not match expected subject ({})",
-            message.subject,
-            value.subject()
-        ));
+    let expected_subject = value.subject();
+    if expected_subject != message.subject {
+        if expected_subject.starts_with("state.cluster.") && expected_subject.ends_with(".assignment") {
+            // Temporarily ignore due to subject renaming.
+        } else {
+            return Err(anyhow!(
+                "Message subject ({}) does not match expected subject ({})",
+                message.subject,
+                value.subject()
+            ));
+        }        
     }
 
     Ok(value)


### PR DESCRIPTION
The subject for assignment messages was renamed from `state.cluster.{}.backend.{}` to `state.cluster.{}.backend.{}.assignment` for consistency with `state.cluster.{}.backend.{}.lock`.

This allows both message types to be used for an interim period, so that deploying still captures existing backends on all subjects. After this has been live for long enough for existing drones to be cycled out, we can roll this back.