### PR TITLE
Remove message subject check special case

### DIFF
--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -122,19 +122,12 @@ where
 /// expected subject for that message.
 fn parse_and_verify_message<T: TypedMessage>(message: &Message) -> Result<T> {
     let value: T = serde_json::from_slice(&message.payload)?;
-    let expected_subject = value.subject();
-    if expected_subject != message.subject {
-        if expected_subject.starts_with("state.cluster.")
-            && expected_subject.ends_with(".assignment")
-        {
-            // Temporarily ignore due to subject renaming.
-        } else {
-            return Err(anyhow!(
-                "Message subject ({}) does not match expected subject ({})",
-                message.subject,
-                value.subject()
-            ));
-        }
+    if value.subject() != message.subject {
+        return Err(anyhow!(
+            "Message subject ({}) does not match expected subject ({})",
+            message.subject,
+            value.subject()
+        ));
     }
 
     Ok(value)


### PR DESCRIPTION
Before merging, check that all messages with the old subject schema have been removed.

The easiest way to do this is by running `dump-state` and looking for errors.