### PR TITLE
schema for world state messages from serde::Serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-schema-map"
+version = "0.1.0"
+dependencies = [
+ "plane-core",
+ "serde",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "controller",
     "core",
     "core/nats-macros",
+    "core/gen-schema-map",
     "dev",
     "dev/integration-test",
     "drone",

--- a/core/gen-schema-map/Cargo.toml
+++ b/core/gen-schema-map/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gen-schema-map"
+version = "0.1.0"
+authors = ["Abhishek Cherath <abhi@driftingin.space>"]
+license = "MIT"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+plane-core = {path = "..", version="0.3.5"}
+serde = { version = "1.0.144", features = ["derive"] }

--- a/core/gen-schema-map/src/main.rs
+++ b/core/gen-schema-map/src/main.rs
@@ -1,0 +1,5 @@
+mod serializer;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/core/gen-schema-map/src/serializer.rs
+++ b/core/gen-schema-map/src/serializer.rs
@@ -5,8 +5,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     Message(String),
-	NotEnoughInfo
- }
+    NotEnoughInfo,
+}
 
 impl ser::Error for Error {
     fn custom<T: Display>(msg: T) -> Self {
@@ -18,8 +18,9 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Message(msg) => formatter.write_str(msg),
-			Error::NotEnoughInfo =>
-				formatter.write_str("example thingie does not give me enough to schematize"),
+            Error::NotEnoughInfo => {
+                formatter.write_str("example thingie does not give me enough to schematize")
+            }
         }
     }
 }
@@ -27,16 +28,16 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 pub struct Serializer {
-	output: String
+    output: String,
 }
 
 pub struct KeySerializer {
-	output: String
+    output: String,
 }
 
 impl<'a> ser::Serializer for &'a mut KeySerializer {
-	type Ok = ();
-	type Error = Error;
+    type Ok = ();
+    type Error = Error;
     type SerializeSeq = &'a mut Serializer;
     type SerializeTuple = &'a mut Serializer;
     type SerializeTupleStruct = &'a mut Serializer;
@@ -44,7 +45,6 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
     type SerializeMap = &'a mut Serializer;
     type SerializeStruct = &'a mut Serializer;
     type SerializeStructVariant = &'a mut Serializer;
-
 
     fn serialize_str(self, v: &str) -> Result<()> {
         self.output += v;
@@ -109,7 +109,8 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> std::result::Result<Self::Ok, Self::Error>
     where
-        T: Serialize {
+        T: Serialize,
+    {
         todo!()
     }
 
@@ -117,7 +118,10 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
         todo!()
     }
 
-    fn serialize_unit_struct(self, name: &'static str) -> std::result::Result<Self::Ok, Self::Error> {
+    fn serialize_unit_struct(
+        self,
+        name: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
         todo!()
     }
 
@@ -136,7 +140,8 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
         value: &T,
     ) -> std::result::Result<Self::Ok, Self::Error>
     where
-        T: Serialize {
+        T: Serialize,
+    {
         todo!()
     }
 
@@ -148,11 +153,15 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
         value: &T,
     ) -> std::result::Result<Self::Ok, Self::Error>
     where
-        T: Serialize {
+        T: Serialize,
+    {
         todo!()
     }
 
-    fn serialize_seq(self, len: Option<usize>) -> std::result::Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(
+        self,
+        len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeSeq, Self::Error> {
         todo!()
     }
 
@@ -178,7 +187,10 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
         todo!()
     }
 
-    fn serialize_map(self, len: Option<usize>) -> std::result::Result<Self::SerializeMap, Self::Error> {
+    fn serialize_map(
+        self,
+        len: Option<usize>,
+    ) -> std::result::Result<Self::SerializeMap, Self::Error> {
         todo!()
     }
 
@@ -199,20 +211,19 @@ impl<'a> ser::Serializer for &'a mut KeySerializer {
     ) -> std::result::Result<Self::SerializeStructVariant, Self::Error> {
         todo!()
     }
-
 }
 
-pub fn to_model_string<T: Serialize,>(value: &T) -> Result<String> {
-	let mut serializer = Serializer {
-		output: String::new()
-	};
-	value.serialize(&mut serializer)?;
-	Ok(serializer.output)
+pub fn to_model_string<T: Serialize>(value: &T) -> Result<String> {
+    let mut serializer = Serializer {
+        output: String::new(),
+    };
+    value.serialize(&mut serializer)?;
+    Ok(serializer.output)
 }
 
 impl<'a> ser::Serializer for &'a mut Serializer {
-	type Ok = ();
-	type Error = Error;
+    type Ok = ();
+    type Error = Error;
 
     type SerializeSeq = Self;
     type SerializeTuple = Self;
@@ -288,7 +299,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_none(self) -> Result<()> {
-		Err(Error::NotEnoughInfo)
+        Err(Error::NotEnoughInfo)
     }
 
     fn serialize_some<T>(self, value: &T) -> Result<()>
@@ -299,7 +310,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_unit(self) -> Result<()> {
-		//shouldnt be possible? I think?
+        //shouldnt be possible? I think?
         self.output += "null";
         Ok(())
     }
@@ -317,11 +328,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
@@ -339,7 +346,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         T: ?Sized + Serialize,
     {
         self.output += "{";
-		self.output += variant;
+        self.output += variant;
         //variant.serialize(&mut *self)?;
         self.output += ":";
         value.serialize(&mut *self)?;
@@ -353,8 +360,8 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
-		self.output += "(";
-		Ok(self)
+        self.output += "(";
+        Ok(self)
         //self.serialize_seq(Some(len))
     }
 
@@ -374,7 +381,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
         self.output += "{";
-		self.output += variant;
+        self.output += variant;
         //variant.serialize(&mut *self)?;
         self.output += ":[";
         Ok(self)
@@ -385,11 +392,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         Ok(self)
     }
 
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStruct> {
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
         self.serialize_map(Some(len))
     }
 
@@ -421,9 +424,9 @@ impl<'a> ser::SerializeSeq for &'a mut Serializer {
     {
         if self.output.ends_with('[') {
             //self.output += ",";
-			value.serialize(&mut **self)?;
-        } 
-		Ok(())
+            value.serialize(&mut **self)?;
+        }
+        Ok(())
     }
 
     // Close the sequence.
@@ -504,7 +507,6 @@ impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
     }
 }
 
-
 // Some `Serialize` types are not able to hold a key and value in memory at the
 // same time so `SerializeMap` implementations are required to support
 // `serialize_key` and `serialize_value` individually.
@@ -533,13 +535,13 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
             self.output += ",";
         }
 
-		let mut serializer = KeySerializer {
-			output: String::new()
-		};
+        let mut serializer = KeySerializer {
+            output: String::new(),
+        };
 
-		key.serialize(&mut serializer)?;
-		self.output += &serializer.output;
-		Ok(())
+        key.serialize(&mut serializer)?;
+        self.output += &serializer.output;
+        Ok(())
     }
 
     // It doesn't make a difference whether the colon is printed at the end of
@@ -573,12 +575,12 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
             self.output += ",";
         }
 
-		let mut serializer = KeySerializer {
-			output: String::new()
-		};
+        let mut serializer = KeySerializer {
+            output: String::new(),
+        };
 
-		key.serialize(&mut serializer)?;
-		self.output += &serializer.output;
+        key.serialize(&mut serializer)?;
+        self.output += &serializer.output;
 
         self.output += ":";
         value.serialize(&mut **self)
@@ -604,12 +606,12 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
             self.output += ",";
         }
 
-		let mut serializer = KeySerializer {
-			output: String::new()
-		};
+        let mut serializer = KeySerializer {
+            output: String::new(),
+        };
 
-		key.serialize(&mut serializer)?;
-		self.output += &serializer.output;
+        key.serialize(&mut serializer)?;
+        self.output += &serializer.output;
 
         self.output += ":";
         value.serialize(&mut **self)
@@ -634,24 +636,24 @@ fn test_struct() {
         seq: vec!["a", "b"],
     };
 
-	let expected = "{int:number,seq:[string]}";
-	let mut model_string = to_model_string(&test).unwrap();
-	model_string.retain(|c| !c.is_whitespace());
+    let expected = "{int:number,seq:[string]}";
+    let mut model_string = to_model_string(&test).unwrap();
+    model_string.retain(|c| !c.is_whitespace());
 
-	assert_eq!(model_string, expected);
+    assert_eq!(model_string, expected);
 
     #[derive(Serialize)]
     struct Test2 {
         int: u32,
-        seq: (String, String)
+        seq: (String, String),
     }
-	let test = Test2 {
-		int: 1,
-		seq: ("a".into(), "b".into())
-	};
+    let test = Test2 {
+        int: 1,
+        seq: ("a".into(), "b".into()),
+    };
 
     let expected = "{int:number,seq:(string,string)}";
-	let mut model_string = to_model_string(&test).unwrap();
-	model_string.retain(|c| !c.is_whitespace());
+    let mut model_string = to_model_string(&test).unwrap();
+    model_string.retain(|c| !c.is_whitespace());
     assert_eq!(model_string, expected);
 }

--- a/core/gen-schema-map/src/serializer.rs
+++ b/core/gen-schema-map/src/serializer.rs
@@ -1,0 +1,657 @@
+use serde::{ser, Serialize};
+use std::{fmt, fmt::Display};
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    Message(String),
+	NotEnoughInfo
+ }
+
+impl ser::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Error::Message(msg.to_string())
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Message(msg) => formatter.write_str(msg),
+			Error::NotEnoughInfo =>
+				formatter.write_str("example thingie does not give me enough to schematize"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub struct Serializer {
+	output: String
+}
+
+pub struct KeySerializer {
+	output: String
+}
+
+impl<'a> ser::Serializer for &'a mut KeySerializer {
+	type Ok = ();
+	type Error = Error;
+    type SerializeSeq = &'a mut Serializer;
+    type SerializeTuple = &'a mut Serializer;
+    type SerializeTupleStruct = &'a mut Serializer;
+    type SerializeTupleVariant = &'a mut Serializer;
+    type SerializeMap = &'a mut Serializer;
+    type SerializeStruct = &'a mut Serializer;
+    type SerializeStructVariant = &'a mut Serializer;
+
+
+    fn serialize_str(self, v: &str) -> Result<()> {
+        self.output += v;
+        Ok(())
+    }
+
+    fn serialize_bool(self, v: bool) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i8(self, v: i8) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i16(self, v: i16) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i32(self, v: i32) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_i64(self, v: i64) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u8(self, v: u8) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u16(self, v: u16) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u32(self, v: u32) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_u64(self, v: u64) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f32(self, v: f32) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_f64(self, v: f64) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_char(self, v: char) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_none(self) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: Serialize {
+        todo!()
+    }
+
+    fn serialize_unit(self) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> std::result::Result<Self::Ok, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: Serialize {
+        todo!()
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> std::result::Result<Self::Ok, Self::Error>
+    where
+        T: Serialize {
+        todo!()
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> std::result::Result<Self::SerializeSeq, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple(self, len: usize) -> std::result::Result<Self::SerializeTuple, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeTupleStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeTupleVariant, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> std::result::Result<Self::SerializeMap, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeStruct, Self::Error> {
+        todo!()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> std::result::Result<Self::SerializeStructVariant, Self::Error> {
+        todo!()
+    }
+
+}
+
+pub fn to_model_string<T: Serialize,>(value: &T) -> Result<String> {
+	let mut serializer = Serializer {
+		output: String::new()
+	};
+	value.serialize(&mut serializer)?;
+	Ok(serializer.output)
+}
+
+impl<'a> ser::Serializer for &'a mut Serializer {
+	type Ok = ();
+	type Error = Error;
+
+    type SerializeSeq = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<()> {
+        self.output += "bool";
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<()> {
+        self.serialize_i64(i64::from(v))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<()> {
+        self.serialize_i64(i64::from(v))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<()> {
+        self.serialize_i64(i64::from(v))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<()> {
+        self.output += "number";
+        Ok(())
+    }
+    fn serialize_u8(self, v: u8) -> Result<()> {
+        self.serialize_u64(u64::from(v))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<()> {
+        self.serialize_u64(u64::from(v))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<()> {
+        self.serialize_u64(u64::from(v))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<()> {
+        self.output += "number";
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<()> {
+        self.serialize_f64(f64::from(v))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<()> {
+        self.output += "number";
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<()> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<()> {
+        self.output += "string";
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+        use serde::ser::SerializeSeq;
+        let mut seq = self.serialize_seq(Some(v.len()))?;
+        for byte in v {
+            seq.serialize_element(byte)?;
+        }
+        seq.end()
+    }
+
+    fn serialize_none(self) -> Result<()> {
+		Err(Error::NotEnoughInfo)
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+		//shouldnt be possible? I think?
+        self.output += "null";
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<()> {
+        self.serialize_str(variant)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += "{";
+		self.output += variant;
+        //variant.serialize(&mut *self)?;
+        self.output += ":";
+        value.serialize(&mut *self)?;
+        self.output += "}";
+        Ok(())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        self.output += "[";
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+		self.output += "(";
+		Ok(self)
+        //self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_tuple(len)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        self.output += "{";
+		self.output += variant;
+        //variant.serialize(&mut *self)?;
+        self.output += ":[";
+        Ok(self)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        self.output += "{";
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        self.output += "{";
+        self.output += variant;
+        //variant.serialize(&mut *self)?;
+        self.output += ":{";
+        Ok(self)
+    }
+}
+
+impl<'a> ser::SerializeSeq for &'a mut Serializer {
+    // Must match the `Ok` type of the serializer.
+    type Ok = ();
+    // Must match the `Error` type of the serializer.
+    type Error = Error;
+
+    // Serialize a single element of the sequence.
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if self.output.ends_with('[') {
+            //self.output += ",";
+			value.serialize(&mut **self)?;
+        } 
+		Ok(())
+    }
+
+    // Close the sequence.
+    fn end(self) -> Result<()> {
+        self.output += "]\n";
+        Ok(())
+    }
+}
+
+// Same thing but for tuples.
+impl<'a> ser::SerializeTuple for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('(') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += ")\n";
+        Ok(())
+    }
+}
+
+// Same thing but for tuple structs.
+impl<'a> ser::SerializeTupleStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('(') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += ")\n";
+        Ok(())
+    }
+}
+
+// Tuple variants are a little different. Refer back to the
+// `serialize_tuple_variant` method above:
+//
+//    self.output += "{";
+//    variant.serialize(&mut *self)?;
+//    self.output += ":[";
+//
+// So the `end` method in this impl is responsible for closing both the `]` and
+// the `}`.
+impl<'a> ser::SerializeTupleVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('(') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += ")}\n";
+        Ok(())
+    }
+}
+
+
+// Some `Serialize` types are not able to hold a key and value in memory at the
+// same time so `SerializeMap` implementations are required to support
+// `serialize_key` and `serialize_value` individually.
+//
+// There is a third optional method on the `SerializeMap` trait. The
+// `serialize_entry` method allows serializers to optimize for the case where
+// key and value are both available simultaneously. In JSON it doesn't make a
+// difference so the default behavior for `serialize_entry` is fine.
+impl<'a> ser::SerializeMap for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    // The Serde data model allows map keys to be any serializable type. JSON
+    // only allows string keys so the implementation below will produce invalid
+    // JSON if the key serializes as something other than a string.
+    //
+    // A real JSON serializer would need to validate that map keys are strings.
+    // This can be done by using a different Serializer to serialize the key
+    // (instead of `&mut **self`) and having that other serializer only
+    // implement `serialize_str` and return an error on any other data type.
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+
+		let mut serializer = KeySerializer {
+			output: String::new()
+		};
+
+		key.serialize(&mut serializer)?;
+		self.output += &serializer.output;
+		Ok(())
+    }
+
+    // It doesn't make a difference whether the colon is printed at the end of
+    // `serialize_key` or at the beginning of `serialize_value`. In this case
+    // the code is a bit simpler having it here.
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += "}\n";
+        Ok(())
+    }
+}
+
+// Structs are like maps in which the keys are constrained to be compile-time
+// constant strings.
+impl<'a> ser::SerializeStruct for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+
+		let mut serializer = KeySerializer {
+			output: String::new()
+		};
+
+		key.serialize(&mut serializer)?;
+		self.output += &serializer.output;
+
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += "}\n";
+        Ok(())
+    }
+}
+
+// Similar to `SerializeTupleVariant`, here the `end` method is responsible for
+// closing both of the curly braces opened by `serialize_struct_variant`.
+impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if !self.output.ends_with('{') {
+            self.output += ",";
+        }
+
+		let mut serializer = KeySerializer {
+			output: String::new()
+		};
+
+		key.serialize(&mut serializer)?;
+		self.output += &serializer.output;
+
+        self.output += ":";
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        self.output += "}}\n";
+        Ok(())
+    }
+}
+
+#[test]
+fn test_struct() {
+    #[derive(Serialize)]
+    struct Test {
+        int: u32,
+        seq: Vec<&'static str>,
+    }
+
+    let test = Test {
+        int: 1,
+        seq: vec!["a", "b"],
+    };
+
+	let expected = "{int:number,seq:[string]}";
+	let mut model_string = to_model_string(&test).unwrap();
+	model_string.retain(|c| !c.is_whitespace());
+
+	assert_eq!(model_string, expected);
+
+    #[derive(Serialize)]
+    struct Test2 {
+        int: u32,
+        seq: (String, String)
+    }
+	let test = Test2 {
+		int: 1,
+		seq: ("a".into(), "b".into())
+	};
+
+    let expected = "{int:number,seq:(string,string)}";
+	let mut model_string = to_model_string(&test).unwrap();
+	model_string.retain(|c| !c.is_whitespace());
+    assert_eq!(model_string, expected);
+}


### PR DESCRIPTION
the idea here is to have a small canary of sorts that notifies us if the schema's changed and how, I thought about using one of the existing libraries but they all involve adding tags and stuff and I didn't like that. This just abuses the Serialize trait.

the idea is that we'd have a plain text world_state_schema.txt (checked into VC) file of the forme:
```
subject:
{<<schema>>}
next_subject:
{<<schema>>}
```
and a test that fails if the current schema is different.

I've only implemented the serializer thing thus far, would like some thoughts before continuing

Of course, in the future one can imagine all sorts of cool macro stuff too, but I just want to have some warning of failure with preexisting jetstream for now.

