### PR TITLE
Add HTTP API to Plane controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,9 +237,10 @@ checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -279,6 +302,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -402,7 +431,7 @@ checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -1016,6 +1045,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1140,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -1239,7 +1299,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -1352,7 +1412,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1540,7 +1600,7 @@ version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1618,7 +1678,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1818,6 +1878,7 @@ name = "plane-controller"
 version = "0.3.23"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum",
  "chrono",
@@ -1829,6 +1890,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tower-http",
  "tracing",
  "trust-dns-server",
 ]
@@ -2079,7 +2141,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2088,7 +2150,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2198,7 +2260,7 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2313,7 +2375,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2618,7 +2680,7 @@ checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "bytes",
  "crc",
@@ -2983,6 +3045,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+dependencies = [
+ "bitflags 2.4.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1819,7 @@ version = "0.3.23"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "futures",
@@ -2206,6 +2262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2380,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae801b7733ca8d6a2b580debe99f67f36826a0f5b8a36055dc6bc40f8d6bc71"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2663,6 +2735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "sysinfo"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +2970,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,6 +3004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/README.md
+++ b/README.md
@@ -70,9 +70,23 @@ And then access it with:
 
 The Plane controller can also optionally start an HTTP server that supports a subset of the NATS API for spawning.
 
-    curl \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -d '{}' \
-      -D - \
-      localhost:9090/service/hello-world/spawn
+This is intended for development; in production we recommend using the NATS API.
+
+To enable the HTTP server, add an `[http]` block to the controller config. The block requires a `cluster` argument, which specifies the cluster that spawn requests should be spawned to. It also requires a `services` table, which defines a mapping from “service” names to the image to spawn for that service.
+
+```toml
+[http]
+cluster = "plane.test"
+services.hello-world = "ghcr.io/drifting-in-space/demo-image-hello-world:sha-3b58532"
+```
+
+By default, the controller HTTP server runs on port 9090. You can send a spawn request over HTTP like this:
+
+```bash
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  -D - \
+  localhost:9090/service/hello-world/spawn
+```

--- a/README.md
+++ b/README.md
@@ -65,3 +65,14 @@ Then, you can use the CLI with `./dev-cli.sh`. For example, you can spawn a hell
 And then access it with:
 
     ./dev-curl.sh [URL returned after spawn]
+
+## Spawning over HTTP
+
+The Plane controller can also optionally start an HTTP server that supports a subset of the NATS API for spawning.
+
+    curl \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d '{}' \
+      -D - \
+      localhost:9090/service/hello-world/spawn

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -23,7 +23,9 @@ tokio-stream = "0.1.9"
 tracing = "0.1.36"
 trust-dns-server = "0.22.0"
 serde_json = "1.0.95"
-axum = "0.6.20"
+axum = { version = "0.6.20", features = ["headers"] }
+tower-http = { version = "0.4.3", features = ["cors"] }
+async-stream = "0.3.5"
 
 [[bin]]
 name = "plane-controller"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -23,6 +23,7 @@ tokio-stream = "0.1.9"
 tracing = "0.1.36"
 trust-dns-server = "0.22.0"
 serde_json = "1.0.95"
+axum = "0.6.20"
 
 [[bin]]
 name = "plane-controller"

--- a/controller/src/config.rs
+++ b/controller/src/config.rs
@@ -1,6 +1,9 @@
 use plane_core::{nats_connection::NatsConnectionSpec, types::ClusterName};
 use serde::{Deserialize, Serialize};
-use std::{net::{IpAddr, Ipv4Addr}, collections::HashMap};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct SchedulerOptions {}

--- a/controller/src/config.rs
+++ b/controller/src/config.rs
@@ -1,13 +1,13 @@
-use plane_core::nats_connection::NatsConnectionSpec;
+use plane_core::{nats_connection::NatsConnectionSpec, types::ClusterName};
 use serde::{Deserialize, Serialize};
-use std::net::{IpAddr, Ipv4Addr};
+use std::{net::{IpAddr, Ipv4Addr}, collections::HashMap};
 
 #[derive(Serialize, Deserialize)]
 pub struct SchedulerOptions {}
 
 #[derive(Serialize, Deserialize)]
 pub struct DnsOptions {
-    #[serde(default = "default_port")]
+    #[serde(default = "default_dns_port")]
     pub port: u16,
 
     #[serde(default = "default_bind_ip")]
@@ -24,12 +24,29 @@ pub struct DnsOptions {
     pub domain_name: Option<String>,
 }
 
-fn default_port() -> u16 {
+fn default_dns_port() -> u16 {
     53
+}
+
+fn default_http_port() -> u16 {
+    9090
 }
 
 fn default_bind_ip() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct HttpOptions {
+    #[serde(default = "default_http_port")]
+    pub port: u16,
+
+    #[serde(default = "default_bind_ip")]
+    pub bind_ip: IpAddr,
+
+    pub services: HashMap<String, String>,
+
+    pub cluster: ClusterName,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -40,4 +57,6 @@ pub struct ControllerConfig {
     pub scheduler: Option<SchedulerOptions>,
 
     pub dns: Option<DnsOptions>,
+
+    pub http: Option<HttpOptions>,
 }

--- a/controller/src/http_server.rs
+++ b/controller/src/http_server.rs
@@ -1,0 +1,167 @@
+use crate::config::HttpOptions;
+use anyhow::Result;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use plane_core::{
+    messages::{
+        agent::{DockerExecutableConfig, DockerPullPolicy, ResourceLimits},
+        scheduler::{ScheduleRequest, ScheduleResponse},
+    },
+    nats::TypedNats,
+    types::{ClusterName, ResourceLock},
+    Never,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+
+trait LogError<T> {
+    fn log_error(self, status_code: StatusCode) -> Result<T, StatusCode>;
+}
+
+impl<T> LogError<T> for Result<T> {
+    fn log_error(self, status_code: StatusCode) -> Result<T, StatusCode> {
+        match self {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                tracing::error!(error = %e, "HTTP request failed.");
+                Err(status_code)
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct HttpSpawnRequest {
+    grace_period_seconds: Option<u64>,
+    lock: Option<String>,
+    #[serde(default = "bool::default")]
+    require_bearer_token: bool,
+    port: Option<u16>,
+    #[serde(default = "HashMap::default")]
+    env: HashMap<String, String>,
+    #[serde(default = "Vec::default")]
+    volume_mounts: Vec<Value>,
+}
+
+impl HttpSpawnRequest {
+    pub fn into_spawn_request(
+        &self,
+        cluster: ClusterName,
+        image: String,
+    ) -> Result<ScheduleRequest> {
+        let max_idle_secs = Duration::from_secs(self.grace_period_seconds.unwrap_or_else(|| 600));
+
+        let lock: Option<ResourceLock> = self.lock.clone().map(|l| l.try_into()).transpose()?;
+
+        let executable = DockerExecutableConfig {
+            image,
+            env: self.env.clone(),
+            credentials: None,
+            resource_limits: ResourceLimits::default(),
+            pull_policy: DockerPullPolicy::default(),
+            port: self.port,
+            volume_mounts: self.volume_mounts.clone(),
+        };
+
+        Ok(ScheduleRequest {
+            cluster,
+            max_idle_secs,
+            lock,
+            require_bearer_token: self.require_bearer_token,
+            backend_id: None,
+            metadata: HashMap::new(),
+            executable,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct HttpSpawnResponse {
+    url: String,
+    name: String,
+    ready_url: String,
+    status_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bearer_token: Option<String>,
+    spawned: bool,
+}
+
+async fn handle_index() -> &'static str {
+    "Plane controller HTTP server"
+}
+
+async fn handle_spawn(
+    State(server_state): State<Arc<ServerState>>,
+    Path(service): Path<String>,
+    Json(request): Json<HttpSpawnRequest>,
+) -> Result<Json<HttpSpawnResponse>, StatusCode> {
+    let service = server_state
+        .services
+        .get(&service)
+        .ok_or_else(|| StatusCode::NOT_FOUND)?;
+
+    let request = request
+        .into_spawn_request(server_state.cluster.clone(), service.clone())
+        .log_error(StatusCode::BAD_REQUEST)?;
+
+    let response = server_state
+        .nats
+        .request(&request)
+        .await
+        .log_error(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let http_response = match response {
+        ScheduleResponse::Scheduled {
+            backend_id,
+            bearer_token,
+            spawned,
+            ..
+        } => HttpSpawnResponse {
+            url: format!(
+                "http://{}.{}",
+                backend_id.to_string(),
+                server_state.cluster.to_string(),
+            ),
+            name: backend_id.to_string(),
+            ready_url: format!("__todo"),
+            status_url: format!("__todo"),
+            bearer_token,
+            spawned,
+        },
+        ScheduleResponse::NoDroneAvailable => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+
+    Ok(Json(http_response))
+}
+
+struct ServerState {
+    pub nats: TypedNats,
+    pub services: HashMap<String, String>,
+    pub cluster: ClusterName,
+}
+
+pub async fn serve(options: HttpOptions, nats: TypedNats) -> Result<Never> {
+    let addr = SocketAddr::new(options.bind_ip, options.port);
+
+    let server_state = Arc::new(ServerState {
+        nats,
+        services: options.services,
+        cluster: options.cluster,
+    });
+
+    let app = Router::new()
+        .route("/", get(handle_index))
+        .route("/service/:service/spawn", post(handle_spawn))
+        .with_state(server_state);
+
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await?;
+
+    Err(anyhow::anyhow!("HTTP server exited unexpectedly"))
+}

--- a/controller/src/http_server.rs
+++ b/controller/src/http_server.rs
@@ -60,12 +60,11 @@ struct HttpSpawnRequest {
 }
 
 impl HttpSpawnRequest {
-    pub fn as_spawn_request(
-        &self,
-        cluster: ClusterName,
-        image: String,
-    ) -> Result<ScheduleRequest> {
-        let max_idle_secs = Duration::from_secs(self.grace_period_seconds.unwrap_or(DEFAULT_GRACE_PERIOD_SECONDS));
+    pub fn as_spawn_request(&self, cluster: ClusterName, image: String) -> Result<ScheduleRequest> {
+        let max_idle_secs = Duration::from_secs(
+            self.grace_period_seconds
+                .unwrap_or(DEFAULT_GRACE_PERIOD_SECONDS),
+        );
 
         let lock: Option<ResourceLock> = self.lock.clone().map(|l| l.try_into()).transpose()?;
 
@@ -135,11 +134,7 @@ async fn handle_spawn(
             spawned,
             ..
         } => HttpSpawnResponse {
-            url: format!(
-                "http://{}.{}",
-                backend_id,
-                server_state.cluster,
-            ),
+            url: format!("http://{}.{}", backend_id, server_state.cluster,),
             name: backend_id.to_string(),
             status_url: format!("http://{}/backend/{}/status", host, backend_id),
             bearer_token,

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -24,6 +24,7 @@ use scheduler::Scheduler;
 mod config;
 pub mod dns;
 pub mod drone_state;
+pub mod http_server;
 pub mod plan;
 pub mod run;
 mod scheduler;

--- a/controller/src/plan.rs
+++ b/controller/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::{config::ControllerConfig, dns::rname_format::format_rname};
+use crate::{config::{ControllerConfig, HttpOptions}, dns::rname_format::format_rname};
 use anyhow::{Context, Result};
 use plane_core::{
     nats::TypedNats,
@@ -23,6 +23,7 @@ pub struct ControllerPlan {
     pub scheduler_plan: Option<SchedulerPlan>,
     pub dns_plan: Option<DnsPlan>,
     pub state: StateHandle,
+    pub http_plan: Option<HttpOptions>,
 }
 
 impl ControllerPlan {
@@ -72,11 +73,14 @@ impl ControllerPlan {
             None
         };
 
+         let http_plan = config.http;
+
         Ok(ControllerPlan {
             nats,
             scheduler_plan,
             dns_plan,
             state,
+            http_plan,
         })
     }
 }

--- a/controller/src/plan.rs
+++ b/controller/src/plan.rs
@@ -1,4 +1,7 @@
-use crate::{config::{ControllerConfig, HttpOptions}, dns::rname_format::format_rname};
+use crate::{
+    config::{ControllerConfig, HttpOptions},
+    dns::rname_format::format_rname,
+};
 use anyhow::{Context, Result};
 use plane_core::{
     nats::TypedNats,
@@ -73,7 +76,7 @@ impl ControllerPlan {
             None
         };
 
-         let http_plan = config.http;
+        let http_plan = config.http;
 
         Ok(ControllerPlan {
             nats,

--- a/controller/src/run.rs
+++ b/controller/src/run.rs
@@ -107,7 +107,7 @@ async fn controller_main() -> Result<()> {
         Supervisor::new("heartbeat", move || heartbeat(nats.clone()))
     };
 
-     let _http_supervisor = if let Some(http_options) = http_plan {
+    let _http_supervisor = if let Some(http_options) = http_plan {
         let nats = nats.clone();
         let http_options = http_options.clone();
         Some(Supervisor::new("http", move || {

--- a/controller/src/run.rs
+++ b/controller/src/run.rs
@@ -109,7 +109,7 @@ async fn controller_main() -> Result<()> {
 
     let _http_supervisor = if let Some(http_options) = http_plan {
         let nats = nats.clone();
-        let http_options = http_options.clone();
+        let http_options = http_options;
         Some(Supervisor::new("http", move || {
             crate::http_server::serve(http_options.clone(), nats.clone())
         }))

--- a/controller/src/run.rs
+++ b/controller/src/run.rs
@@ -62,6 +62,7 @@ async fn controller_main() -> Result<()> {
         dns_plan,
         scheduler_plan,
         state,
+        http_plan,
     } = plan;
 
     tracing_handle.attach_nats(nats.clone())?;
@@ -104,6 +105,16 @@ async fn controller_main() -> Result<()> {
     let _heartbeat_supervisor = {
         let nats = nats.clone();
         Supervisor::new("heartbeat", move || heartbeat(nats.clone()))
+    };
+
+     let _http_supervisor = if let Some(http_options) = http_plan {
+        let nats = nats.clone();
+        let http_options = http_options.clone();
+        Some(Supervisor::new("http", move || {
+            crate::http_server::serve(http_options.clone(), nats.clone())
+        }))
+    } else {
+        None
     };
 
     wait_for_interrupt().await

--- a/dev-nats.sh
+++ b/dev-nats.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-nats-server -js
+docker run -it --rm --name nats-main -p 4222:4222 -p 6222:6222 -p 8222:8222 nats -js

--- a/sample-config/dev-config/controller.toml
+++ b/sample-config/dev-config/controller.toml
@@ -7,3 +7,7 @@ hosts = ["127.0.0.1"]
 port = 5354
 soa_email = "test@example.com"
 domain_name = "ns1.example.com."
+
+[http]
+cluster = "plane.test"
+services.hello-world = "ghcr.io/drifting-in-space/demo-image-hello-world:sha-3b58532"


### PR DESCRIPTION
This implements an HTTP API that is a subset of the NATS API. It aims for compatibility with jamsocket.com, so that jamsocket users can test locally with Plane.