### PR TITLE
limit backend_log to 50gb by default and add option to change it

### DIFF
--- a/controller/src/config.rs
+++ b/controller/src/config.rs
@@ -62,4 +62,6 @@ pub struct ControllerConfig {
     pub dns: Option<DnsOptions>,
 
     pub http: Option<HttpOptions>,
+
+    pub log_stream_size_limit_bytes: Option<i64>,
 }

--- a/controller/src/plan.rs
+++ b/controller/src/plan.rs
@@ -31,7 +31,8 @@ pub struct ControllerPlan {
 
 impl ControllerPlan {
     pub async fn from_controller_config(config: ControllerConfig) -> Result<Self> {
-        let nats = config.nats.connect_with_retry("controller.inbox").await?;
+        let mut nats = config.nats.connect_with_retry("controller.inbox").await?;
+        nats.log_stream_size_limit_bytes = config.log_stream_size_limit_bytes;
         nats.initialize_jetstreams().await?;
         let state = start_state_loop(nats.clone()).await?;
 

--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -108,6 +108,7 @@ impl JetStreamable for DroneLogMessage {
         async_nats::jetstream::stream::Config {
             name: Self::stream_name().into(),
             subjects: vec!["backend.*.log".into()],
+            max_bytes: 50e9 as i64,
             max_messages_per_subject: 500,
             ..async_nats::jetstream::stream::Config::default()
         }

--- a/core/src/messages/mod.rs
+++ b/core/src/messages/mod.rs
@@ -1,5 +1,6 @@
 use crate::nats::JetStreamable;
 use anyhow::anyhow;
+use async_nats::jetstream::stream::Config;
 pub mod agent;
 pub mod cert;
 pub mod dns;
@@ -10,8 +11,9 @@ pub mod state;
 
 async fn add_jetstream_stream<T: JetStreamable>(
     jetstream: &async_nats::jetstream::Context,
+    config: Option<Config>,
 ) -> anyhow::Result<()> {
-    let config = T::config();
+    let config = config.unwrap_or_else(|| T::config());
     tracing::debug!(name = config.name, "Getting or creating jetstream stream.");
     let stream = jetstream
         .get_or_create_stream(config)
@@ -28,11 +30,16 @@ async fn add_jetstream_stream<T: JetStreamable>(
 
 pub async fn initialize_jetstreams(
     jetstream: &async_nats::jetstream::Context,
+    log_stream_size_limit_bytes: Option<i64>,
 ) -> anyhow::Result<()> {
-    add_jetstream_stream::<state::WorldStateMessage>(jetstream).await?;
-    add_jetstream_stream::<agent::DroneLogMessage>(jetstream).await?;
-    add_jetstream_stream::<agent::BackendStateMessage>(jetstream).await?;
-    add_jetstream_stream::<dns::SetDnsRecord>(jetstream).await?;
+    add_jetstream_stream::<state::WorldStateMessage>(jetstream, None).await?;
+    let mut log_config = agent::DroneLogMessage::config();
+    if let Some(limit_bytes) = log_stream_size_limit_bytes {
+        log_config.max_bytes = limit_bytes;
+    }
+    add_jetstream_stream::<agent::DroneLogMessage>(jetstream, Some(log_config)).await?;
+    add_jetstream_stream::<agent::BackendStateMessage>(jetstream, None).await?;
+    add_jetstream_stream::<dns::SetDnsRecord>(jetstream, None).await?;
 
     Ok(())
 }

--- a/core/src/nats.rs
+++ b/core/src/nats.rs
@@ -262,6 +262,7 @@ impl<T> NatsResultExt<T> for std::result::Result<T, async_nats::Error> {
 pub struct TypedNats {
     nc: Client,
     pub jetstream: jetstream::Context,
+    pub log_stream_size_limit_bytes: Option<i64>,
 }
 
 pub struct DelayedReply<T: DeserializeOwned> {
@@ -343,11 +344,15 @@ impl TypedNats {
     pub async fn new(nc: Client) -> Result<Self> {
         let jetstream = async_nats::jetstream::new(nc.clone());
 
-        Ok(TypedNats { nc, jetstream })
+        Ok(TypedNats {
+            nc,
+            jetstream,
+            log_stream_size_limit_bytes: None,
+        })
     }
 
     pub async fn initialize_jetstreams(&self) -> Result<()> {
-        initialize_jetstreams(&self.jetstream).await
+        initialize_jetstreams(&self.jetstream, self.log_stream_size_limit_bytes).await
     }
 
     /// Send a request that expects a reply, but return as soon as the request


### PR DESCRIPTION
this is a reasonable initial limit. also adds log_stream_size_limit_bytes option in controller config to adjust it.