### PR TITLE
add drone id to BackendStats messages

### DIFF
--- a/core/src/messages/agent.rs
+++ b/core/src/messages/agent.rs
@@ -118,6 +118,7 @@ impl JetStreamable for DroneLogMessage {
 #[typed_message(subject = "cluster.#cluster.backend.#backend_id.stats")]
 pub struct BackendStatsMessage {
     pub cluster: ClusterName,
+    pub drone_id: Option<DroneId>,
     pub backend_id: BackendId,
     /// Memory used by backend in bytes
     pub mem_used: u64,
@@ -139,6 +140,7 @@ impl BackendStatsMessage {
     #[cfg(feature = "bollard")]
     pub fn from_stats_messages(
         backend_id: &BackendId,
+        drone_id: &DroneId,
         cluster: &ClusterName,
         prev_stats_message: &Stats,
         cur_stats_message: &Stats,
@@ -183,6 +185,7 @@ impl BackendStatsMessage {
 
         Ok(BackendStatsMessage {
             backend_id: backend_id.clone(),
+            drone_id: Some(drone_id.clone()),
             cluster: cluster.clone(),
             mem_used,
             mem_available,
@@ -358,7 +361,7 @@ pub struct ResourceLimits {
     /// Proportion of period used by container
     pub cpu_period_percent: Option<u8>,
 
-    /// Total cpu time allocated to container    
+    /// Total cpu time allocated to container
     #[serde_as(as = "Option<DurationSeconds>")]
     pub cpu_time_limit: Option<Duration>,
 

--- a/drone/src/agent/engine.rs
+++ b/drone/src/agent/engine.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::Stream;
 use plane_core::{
     messages::agent::{BackendStatsMessage, DroneLogMessage, SpawnRequest},
-    types::{BackendId, ClusterName},
+    types::{BackendId, ClusterName, DroneId},
 };
 use std::{net::SocketAddr, pin::Pin};
 
@@ -51,6 +51,7 @@ pub trait Engine: Send + Sync + 'static {
     fn stats_stream(
         &self,
         backend: &BackendId,
+        drone: &DroneId,
         cluster: &ClusterName,
     ) -> Pin<Box<dyn Stream<Item = BackendStatsMessage> + Send>>;
 }

--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -29,7 +29,7 @@ use plane_core::{
         SpawnRequest,
     },
     timing::Timer,
-    types::{BackendId, ClusterName},
+    types::{BackendId, ClusterName, DroneId},
 };
 use std::time::Duration;
 use std::{net::SocketAddr, pin::Pin};
@@ -423,12 +423,14 @@ impl Engine for DockerInterface {
     fn stats_stream(
         &self,
         backend: &BackendId,
+        drone: &DroneId,
         cluster: &ClusterName,
     ) -> Pin<Box<dyn Stream<Item = BackendStatsMessage> + Send>> {
         let stream = Box::pin(self.get_stats(backend));
         let backend = backend.clone();
+        let drone = drone.clone();
 
-        Box::pin(StatsStream::new(backend, cluster.clone(), stream))
+        Box::pin(StatsStream::new(backend, drone, cluster.clone(), stream))
     }
 
     async fn stop(&self, backend: &BackendId) -> Result<()> {

--- a/drone/src/agent/engines/docker/util.rs
+++ b/drone/src/agent/engines/docker/util.rs
@@ -3,7 +3,10 @@ use bollard::container::Stats;
 use bollard::service::{ContainerInspectResponse, EventMessage};
 use futures::Stream;
 use plane_core::types::ClusterName;
-use plane_core::{messages::agent::BackendStatsMessage, types::BackendId};
+use plane_core::{
+    messages::agent::BackendStatsMessage,
+    types::{BackendId, DroneId},
+};
 use std::{net::IpAddr, pin::Pin, task::Poll};
 
 pub trait MinuteExt {
@@ -164,15 +167,22 @@ pub struct StatsStream<T: Stream<Item = Stats> + Unpin> {
     stream: T,
     last: Option<Stats>,
     backend_id: BackendId,
+    drone_id: DroneId,
     cluster: ClusterName,
 }
 
 impl<T: Stream<Item = Stats> + Unpin> StatsStream<T> {
-    pub fn new(backend_id: BackendId, cluster: ClusterName, stream: T) -> StatsStream<T> {
+    pub fn new(
+        backend_id: BackendId,
+        drone_id: DroneId,
+        cluster: ClusterName,
+        stream: T,
+    ) -> StatsStream<T> {
         StatsStream {
             stream,
             last: None,
             backend_id,
+            drone_id,
             cluster,
         }
     }
@@ -195,6 +205,7 @@ impl<T: Stream<Item = Stats> + Unpin> Stream for StatsStream<T> {
                     if let Some(last) = &self.last {
                         let v = BackendStatsMessage::from_stats_messages(
                             &self.backend_id,
+                            &self.drone_id,
                             &self.cluster,
                             last,
                             &stat,

--- a/drone/src/agent/executor.rs
+++ b/drone/src/agent/executor.rs
@@ -242,6 +242,7 @@ impl<E: Engine> Executor<E> {
                 notify.notified().await;
                 let bm = BackendMonitor::new(
                     &spawn_request.backend_id,
+                    &spawn_request.drone_id,
                     &s.cluster,
                     s.ip,
                     s.engine.as_ref(),


### PR DESCRIPTION
This adds the drone's ID to backend stats messages which helps consumers - specifically metrics consumers - not have to do extra queries before adding relevant tags to the metrics data.