### PR TITLE
Add mark-backend-lost command to mark backends as lost [DIS-1294]

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,9 +94,6 @@ enum Command {
 
         #[arg(required = true)]
         backends: Vec<String>,
-
-        #[clap(short, long, default_value = "false")]
-        force: bool,
     },
 }
 
@@ -479,11 +476,7 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Command::MarkBackendLost {
-            cluster,
-            backends,
-            force,
-        } => {
+        Command::MarkBackendLost { cluster, backends } => {
             let stdin = std::io::stdin();
             let state = get_world_state(nats.clone()).await?;
             let cluster = ClusterName::new(&cluster);
@@ -509,14 +502,12 @@ async fn main() -> Result<()> {
                 if let Some(ref lock) = backend_state.lock {
                     println!("NOTE: backend holds the following lock: {lock}!");
                 }
-                if !force {
-                    println!("are you sure you want to mark this backend as lost?");
-                    println!("(type y and end line to continue, any other input will skip marking this backend as lost)");
-                    let mut confirmation = String::new();
-                    stdin.read_line(&mut confirmation)?;
-                    if confirmation != "y" {
-                        continue;
-                    }
+                println!("are you sure you want to mark this backend as lost?");
+                println!("(type y and end line to continue, any other input will skip marking this backend as lost)");
+                let mut confirmation = String::new();
+                stdin.read_line(&mut confirmation)?;
+                if confirmation != "y" {
+                    continue;
                 }
                 let lost_state_message =
                     BackendStateMessage::new(BackendState::Lost, cluster.clone(), backend);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,7 +89,7 @@ enum Command {
         dry_run: bool,
     },
     /// marks backend(s) as lost.
-    Abandon {
+    MarkBackendLost {
         cluster: String,
 
         #[arg(required = true)]
@@ -476,7 +476,7 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Command::Abandon { cluster, backends } => {
+        Command::MarkBackendLost { cluster, backends } => {
             let cluster = ClusterName::new(&cluster);
             for backend in backends {
                 let backend = BackendId::new(backend);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -498,21 +498,30 @@ async fn main() -> Result<()> {
                         "backend state {} is a terminal state!",
                         backend_state.state().unwrap()
                     );
+                    println!(
+                        "A backend may not have multiple terminal states (this is an invariant)"
+                    );
+                    println!("Therefore, skipping marking backend {backend} as lost");
+                    continue;
                 }
                 if let Some(ref lock) = backend_state.lock {
                     println!("NOTE: backend holds the following lock: {lock}!");
                 }
-                println!("are you sure you want to mark this backend as lost?");
+                println!("are you sure you want to mark this backend: {backend} as lost?");
                 println!("(type y and end line to continue, any other input will skip marking this backend as lost)");
+
                 let mut confirmation = String::new();
                 stdin.read_line(&mut confirmation)?;
                 if confirmation != "y" {
+                    println!("skipping backend: {backend}, not marking as lost");
                     continue;
                 }
+
                 let lost_state_message =
-                    BackendStateMessage::new(BackendState::Lost, cluster.clone(), backend);
+                    BackendStateMessage::new(BackendState::Lost, cluster.clone(), backend.clone());
 
                 nats.publish_jetstream(&lost_state_message).await?;
+                println!("marking backend: {backend} as lost");
             }
         }
     }


### PR DESCRIPTION
This command doesn't do any validation, simply publishes lost messages for the backendids supplied on the command line. I do not think that this command should access the world state to check that the backend exists because it'll slow down the command.

I considered adding an AbandonRequest style thing with something in the controller, but decided against it since it would be strictly more work for no real benefit.