### PR TITLE
turn one_shot off for docker stats

### DIFF
--- a/drone/src/agent/engines/docker/mod.rs
+++ b/drone/src/agent/engines/docker/mod.rs
@@ -94,7 +94,9 @@ impl DockerInterface {
     fn get_stats(&self, backend_id: &BackendId) -> impl Stream<Item = Stats> {
         let options = StatsOptions {
             stream: false,
-            one_shot: true,
+            // one_shot is set to false until https://github.com/fussybeaver/bollard/pull/347
+            // has landed.
+            one_shot: false,
         };
 
         let ticker = IntervalStream::new({


### PR DESCRIPTION
the docker.stats() call fails with stream: false, one_shot: true for docker 24.0.7 (this is because the response for those options now returns an object that does not have the name or id fields set, which bollard considers to be required)

this should be reverted once
https://github.com/fussybeaver/bollard/pull/347 has landed.