### PR TITLE
fix dev/psql.sh script when running docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     networks:
       - plane-dev
+    ports:
+      - "5432:5432"
 
 networks:
   plane-dev:


### PR DESCRIPTION
Small fix that gets `dev/psql.sh` script working when running postgres with docker compose.