### PR TITLE
Improve plane2 preview workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    branches: [ "*" ]
+    branches: [ "main" ]
     paths-ignore: [ "/docs" ]
 
 name: Clippy check

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -2,6 +2,7 @@ name: Rustfmt
 
 on:
   pull_request:
+    branches: [ "main" ]
 
 jobs:
   check_format:

--- a/.github/workflows/plane2-build-image.yml
+++ b/.github/workflows/plane2-build-image.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Build Docker Image (plane2-preview)
 
 on:
   push:

--- a/.github/workflows/plane2-clippy.yml
+++ b/.github/workflows/plane2-clippy.yml
@@ -1,3 +1,5 @@
+name: Run Clippy (plane2-preview)
+
 on:
   pull_request:
     branches: [ "plane2-preview" ]

--- a/.github/workflows/plane2-clippy.yml
+++ b/.github/workflows/plane2-clippy.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ "plane2-preview" ]
 
-name: Clippy check
 jobs:
   check-rust-clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/plane2-rustfmt.yml
+++ b/.github/workflows/plane2-rustfmt.yml
@@ -1,4 +1,4 @@
-name: Check Rust formatting
+name: Check Rust formatting (plane2-preview)
 
 on:
   pull_request:

--- a/.github/workflows/plane2-tests.yml
+++ b/.github/workflows/plane2-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests (plane2-preview)
 
 on:
   push:


### PR DESCRIPTION
- Some existing plane workflows are not configured to run on specific branches; this makes them run only on `main`.
- Adds (plane2-preview) to action names to differentiate them
