### PR TITLE
Return a status URL from connect request

### DIFF
--- a/plane2/src/bin/cli.rs
+++ b/plane2/src/bin/cli.rs
@@ -138,6 +138,7 @@ async fn inner_main(opts: Opts) -> Result<(), PlaneClientError> {
             );
 
             println!("URL: {}", response.url.bright_white());
+            println!("Status URL: {}", response.status_url.bright_white());
 
             if wait {
                 let mut stream = client

--- a/plane2/src/controller/connect.rs
+++ b/plane2/src/controller/connect.rs
@@ -61,7 +61,7 @@ pub async fn handle_connect(
 ) -> Result<Json<ConnectResponse>, Response> {
     let response = controller
         .db
-        .connect(&cluster, &request)
+        .connect(&cluster, &request, &controller.client)
         .await
         .map_err(|e| connect_error_to_response(&e))?;
     Ok(Json(response))

--- a/plane2/src/controller/core.rs
+++ b/plane2/src/controller/core.rs
@@ -1,4 +1,7 @@
+use url::Url;
+
 use crate::{
+    client::PlaneClient,
     database::PlaneDatabase,
     names::{AnyNodeName, ControllerName},
     typed_socket::Handshake,
@@ -10,6 +13,7 @@ use std::net::IpAddr;
 pub struct Controller {
     pub db: PlaneDatabase,
     pub id: ControllerName,
+    pub client: PlaneClient,
 }
 
 pub struct NodeHandle {
@@ -57,7 +61,9 @@ impl Controller {
         })
     }
 
-    pub async fn new(db: PlaneDatabase, id: ControllerName) -> Self {
-        Self { db, id }
+    pub async fn new(db: PlaneDatabase, id: ControllerName, controller_url: Url) -> Self {
+        let client = PlaneClient::new(controller_url);
+
+        Self { db, id, client }
     }
 }

--- a/plane2/src/database/mod.rs
+++ b/plane2/src/database/mod.rs
@@ -9,7 +9,10 @@ use self::{
     node::NodeDatabase,
     subscribe::{EventSubscriptionManager, Notification, NotificationPayload, Subscription},
 };
-use crate::types::{ClusterName, ConnectRequest, ConnectResponse};
+use crate::{
+    client::PlaneClient,
+    types::{ClusterName, ConnectRequest, ConnectResponse},
+};
 use serde_json::Value;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::sync::{Arc, OnceLock};
@@ -83,8 +86,9 @@ impl PlaneDatabase {
         &self,
         cluster: &ClusterName,
         request: &ConnectRequest,
+        client: &PlaneClient,
     ) -> Result<ConnectResponse, ConnectError> {
-        connect::connect(&self.pool, cluster, request).await
+        connect::connect(&self.pool, cluster, request, client).await
     }
 
     fn subscription_manager(&self) -> &EventSubscriptionManager {

--- a/plane2/src/main.rs
+++ b/plane2/src/main.rs
@@ -32,8 +32,11 @@ enum Command {
         #[clap(long, default_value = "8080")]
         port: u16,
 
-        #[clap(long, default_value = "0.0.0.0")]
+        #[clap(long, default_value = "127.0.0.1")]
         host: IpAddr,
+
+        #[clap(long)]
+        controller_url: Option<Url>,
     },
     Drone {
         #[clap(long)]
@@ -102,8 +105,21 @@ enum Command {
 
 async fn run(opts: Opts) -> Result<()> {
     match opts.command {
-        Command::Controller { host, port, db } => {
+        Command::Controller {
+            host,
+            port,
+            db,
+            controller_url,
+        } => {
             let name = ControllerName::new_random();
+
+            let controller_url = match controller_url {
+                Some(url) => url,
+                None => {
+                    let url = Url::parse(&format!("http://{}:{}", host, port))?;
+                    url
+                }
+            };
 
             tracing::info!(%name, "Starting controller. Attempting to connect to database...");
             let db = connect_and_migrate(&db)
@@ -113,7 +129,7 @@ async fn run(opts: Opts) -> Result<()> {
 
             let addr = (host, port).into();
 
-            run_controller(db, addr, name).await?
+            run_controller(db, addr, name, controller_url).await?
         }
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;

--- a/plane2/src/types.rs
+++ b/plane2/src/types.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client::PlaneClient,
     names::{BackendName, Name},
     util::random_prefixed_string,
 };
@@ -329,6 +330,8 @@ pub struct ConnectResponse {
     pub url: String,
 
     pub secret_token: SecretToken,
+
+    pub status_url: String,
 }
 
 impl ConnectResponse {
@@ -338,6 +341,7 @@ impl ConnectResponse {
         spawned: bool,
         token: BearerToken,
         secret_token: SecretToken,
+        client: &PlaneClient,
     ) -> Self {
         let url = if cluster.is_https() {
             format!("https://{}/{}/", cluster, token)
@@ -345,12 +349,15 @@ impl ConnectResponse {
             format!("http://{}/{}/", cluster, token)
         };
 
+        let status_url = client.backend_status_url(cluster, &backend_id).to_string();
+
         Self {
             backend_id,
             spawned,
             token,
             url,
             secret_token,
+            status_url,
         }
     }
 }

--- a/plane2/tests/common/test_env.rs
+++ b/plane2/tests/common/test_env.rs
@@ -19,6 +19,7 @@ use std::{
 };
 use tracing::subscriber::DefaultGuard;
 use tracing_appender::non_blocking::WorkerGuard;
+use url::Url;
 
 const TEST_CLUSTER: &str = "plane.test";
 
@@ -85,10 +86,17 @@ impl TestEnvironment {
     pub async fn controller(&mut self) -> ControllerServer {
         let db = self.db().await;
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let controller =
-            ControllerServer::run_with_listener(db.clone(), listener, ControllerName::new_random())
-                .await
-                .expect("Unable to construct controller.");
+        let url: Url = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let controller = ControllerServer::run_with_listener(
+            db.clone(),
+            listener,
+            ControllerName::new_random(),
+            url,
+        )
+        .await
+        .expect("Unable to construct controller.");
         controller
     }
 


### PR DESCRIPTION
- Adds a cli option to controller to pass a controller URL.
- Pipes a `PlaneClient` through to the database so that it can generate a status URL.

I don't love passing a client around so much and think we could refactor that a bit, but this does the trick for now.