### PR TITLE
Satisfy clippy

### DIFF
--- a/plane2/src/database/connect.rs
+++ b/plane2/src/database/connect.rs
@@ -78,7 +78,7 @@ async fn create_backend_with_lock(
     let mut txn = pool.begin().await?;
 
     let pending_action = BackendAction::Spawn {
-        executable: spawn_config.executable.clone(),
+        executable: Box::new(spawn_config.executable.clone()),
         key: lock.clone(),
     };
 

--- a/plane2/src/drone/executor.rs
+++ b/plane2/src/drone/executor.rs
@@ -99,7 +99,7 @@ impl Executor {
 
                 let manager = BackendManager::new(
                     backend_id.clone(),
-                    executable.clone(),
+                    executable.as_ref().clone(),
                     BackendState::default(),
                     self.docker.clone(),
                     callback,

--- a/plane2/src/protocol.rs
+++ b/plane2/src/protocol.rs
@@ -14,7 +14,7 @@ use std::net::SocketAddr;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum BackendAction {
     Spawn {
-        executable: ExecutorConfig,
+        executable: Box<ExecutorConfig>,
         key: KeyConfig,
     },
     Terminate {


### PR DESCRIPTION
Every instance of a Rust enum takes up as much memory as the largest variant. The executor config is getting big, so it's taking up a lot of space relative to the terminate action.

This PR moves the executor config to the heap by boxing it, which silences the warning.

Note that none of this changes the size of the enum over the wire or in the database, only the in-memory representation.