### PR TITLE
TypedSender alteration

### DIFF
--- a/plane2/src/controller/drone.rs
+++ b/plane2/src/controller/drone.rs
@@ -2,7 +2,7 @@ use super::Controller;
 use crate::{
     controller::error::IntoApiError,
     database::{backend::BackendActionMessage, subscribe::Subscription, PlaneDatabase},
-    protocol::{BackendAction, MessageFromDrone, MessageToDrone},
+    protocol::{BackendAction, Heartbeat, MessageFromDrone, MessageToDrone},
     typed_socket::{server::new_server, TypedSocket},
     types::{ClusterName, NodeId, TerminationKind},
 };
@@ -20,9 +20,9 @@ pub async fn handle_message_from_drone(
     sender: &mut TypedSocket<MessageToDrone>,
 ) -> anyhow::Result<()> {
     match msg {
-        MessageFromDrone::Heartbeat {
+        MessageFromDrone::Heartbeat(Heartbeat {
             local_time_epoch_millis,
-        } => {
+        }) => {
             controller
                 .db
                 .drone()

--- a/plane2/src/drone/heartbeat.rs
+++ b/plane2/src/drone/heartbeat.rs
@@ -1,6 +1,5 @@
 use crate::{
-    heartbeat_consts::HEARTBEAT_INTERVAL, protocol::MessageFromDrone,
-    typed_socket::TypedSocketSender,
+    heartbeat_consts::HEARTBEAT_INTERVAL, protocol::Heartbeat, typed_socket::TypedSocketSender,
 };
 use std::time::SystemTime;
 use tokio::task::JoinHandle;
@@ -11,14 +10,14 @@ pub struct HeartbeatLoop {
 }
 
 impl HeartbeatLoop {
-    pub fn start(sender: TypedSocketSender<MessageFromDrone>) -> Self {
+    pub fn start(sender: TypedSocketSender<Heartbeat>) -> Self {
         let handle = tokio::spawn(async move {
             loop {
                 let local_time_epoch_millis = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("system time is before epoch")
                     .as_millis() as u64;
-                if let Err(err) = sender.send(MessageFromDrone::Heartbeat {
+                if let Err(err) = sender.send(Heartbeat {
                     local_time_epoch_millis,
                 }) {
                     tracing::error!(?err, "failed to send heartbeat");

--- a/plane2/src/drone/mod.rs
+++ b/plane2/src/drone/mod.rs
@@ -36,12 +36,12 @@ pub async fn drone_loop(
     loop {
         let mut socket = connection.connect_with_retry(&name).await;
         let _heartbeat_guard =
-            HeartbeatLoop::start(socket.sender(|d| MessageFromDrone::Heartbeat(d)));
+            HeartbeatLoop::start(socket.sender(MessageFromDrone::Heartbeat));
 
         {
             // Forward state changes to the socket.
             // This will start by sending any existing unacked events.
-            let sender = socket.sender(|e| MessageFromDrone::BackendEvent(e));
+            let sender = socket.sender(MessageFromDrone::BackendEvent);
             if let Err(err) = executor.register_listener(move |message| {
                 if let Err(e) = sender.send(message) {
                     tracing::error!(%e, "Error sending message.");

--- a/plane2/src/drone/mod.rs
+++ b/plane2/src/drone/mod.rs
@@ -35,8 +35,7 @@ pub async fn drone_loop(
 ) {
     loop {
         let mut socket = connection.connect_with_retry(&name).await;
-        let _heartbeat_guard =
-            HeartbeatLoop::start(socket.sender(MessageFromDrone::Heartbeat));
+        let _heartbeat_guard = HeartbeatLoop::start(socket.sender(MessageFromDrone::Heartbeat));
 
         {
             // Forward state changes to the socket.

--- a/plane2/src/protocol.rs
+++ b/plane2/src/protocol.rs
@@ -53,8 +53,13 @@ impl From<BackendEventId> for i64 {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Heartbeat {
+    pub local_time_epoch_millis: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MessageFromDrone {
-    Heartbeat { local_time_epoch_millis: u64 },
+    Heartbeat(Heartbeat),
     BackendEvent(BackendStateMessage),
     AckAction { action_id: BackendActionName },
 }

--- a/plane2/src/proxy/proxy_connection.rs
+++ b/plane2/src/proxy/proxy_connection.rs
@@ -32,20 +32,20 @@ impl ProxyConnection {
                     let mut conn = proxy_connection.connect_with_retry(&name).await;
                     state.set_connected(true);
 
-                    let sender = conn.sender(|m| MessageFromProxy::CertManagerRequest(m));
+                    let sender = conn.sender(MessageFromProxy::CertManagerRequest);
                     cert_manager.set_request_sender(move |m| {
                         if let Err(e) = sender.send(m) {
                             tracing::error!(?e, "Error sending cert manager request.");
                         }
                     });
 
-                    let sender = conn.sender(|m| MessageFromProxy::RouteInfoRequest(m));
+                    let sender = conn.sender(MessageFromProxy::RouteInfoRequest);
                     state.route_map.set_sender(move |m: RouteInfoRequest| {
                         if let Err(e) = sender.send(m) {
                             tracing::error!(?e, "Error sending route info request.");
                         }
                     });
-                    let sender = conn.sender(|m| MessageFromProxy::KeepAlive(m));
+                    let sender = conn.sender(MessageFromProxy::KeepAlive);
                     state.monitor.set_listener(move |backend| {
                         if let Err(err) = sender.send(backend.clone()) {
                             tracing::error!(?err, "Error sending keepalive.");

--- a/plane2/src/proxy/proxy_connection.rs
+++ b/plane2/src/proxy/proxy_connection.rs
@@ -32,23 +32,22 @@ impl ProxyConnection {
                     let mut conn = proxy_connection.connect_with_retry(&name).await;
                     state.set_connected(true);
 
-                    let sender = conn.sender();
+                    let sender = conn.sender(|m| MessageFromProxy::CertManagerRequest(m));
                     cert_manager.set_request_sender(move |m| {
-                        if let Err(e) = sender.send(MessageFromProxy::CertManagerRequest(m)) {
+                        if let Err(e) = sender.send(m) {
                             tracing::error!(?e, "Error sending cert manager request.");
                         }
                     });
 
-                    let sender = conn.sender();
+                    let sender = conn.sender(|m| MessageFromProxy::RouteInfoRequest(m));
                     state.route_map.set_sender(move |m: RouteInfoRequest| {
-                        if let Err(e) = sender.send(MessageFromProxy::RouteInfoRequest(m)) {
+                        if let Err(e) = sender.send(m) {
                             tracing::error!(?e, "Error sending route info request.");
                         }
                     });
-                    let sender = conn.sender();
+                    let sender = conn.sender(|m| MessageFromProxy::KeepAlive(m));
                     state.monitor.set_listener(move |backend| {
-                        if let Err(err) = sender.send(MessageFromProxy::KeepAlive(backend.clone()))
-                        {
+                        if let Err(err) = sender.send(backend.clone()) {
                             tracing::error!(?err, "Error sending keepalive.");
                         }
                     });

--- a/plane2/src/typed_socket/mod.rs
+++ b/plane2/src/typed_socket/mod.rs
@@ -1,8 +1,8 @@
 use crate::PlaneVersionInfo;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc::error::TrySendError;
 use std::fmt::Debug;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 pub mod client;
@@ -24,7 +24,8 @@ pub struct TypedSocket<T: ChannelMessage> {
 }
 
 pub struct TypedSocketSender<A> {
-    inner_send: Box<dyn Fn(SocketAction<A>) -> Result<(), TypedSocketError> + 'static + Send + Sync>,
+    inner_send:
+        Box<dyn Fn(SocketAction<A>) -> Result<(), TypedSocketError> + 'static + Send + Sync>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/plane2/src/types.rs
+++ b/plane2/src/types.rs
@@ -1,8 +1,4 @@
-use crate::{
-    client::PlaneClient,
-    names::{BackendName, Name},
-    util::random_prefixed_string,
-};
+use crate::{client::PlaneClient, names::BackendName, util::random_prefixed_string};
 use bollard::auth::DockerCredentials;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/plane2/tests/backend_actions.rs
+++ b/plane2/tests/backend_actions.rs
@@ -4,7 +4,7 @@ use plane2::{
     client::PlaneClientError,
     database::backend::BackendActionMessage,
     names::{DroneName, Name},
-    protocol::{BackendAction, MessageFromDrone, MessageToDrone},
+    protocol::{BackendAction, Heartbeat, MessageFromDrone, MessageToDrone},
     types::{ConnectRequest, ConnectResponse, ExecutorConfig, SpawnConfig},
 };
 use plane_test_macro::plane_test;
@@ -59,9 +59,9 @@ async fn backend_action_resent_if_not_acked(env: TestEnvironment) {
 
         tracing::info!("Sending initial heartbeat message (mocking the drone).");
         drone_connection
-            .send(MessageFromDrone::Heartbeat {
+            .send(MessageFromDrone::Heartbeat(Heartbeat {
                 local_time_epoch_millis: 0, // Doesn't matter for this test.
-            })
+            }))
             .await
             .unwrap();
 


### PR DESCRIPTION
From a `TypedSocket` connection, we have a way to create a `TypedSocketSender` which lets us send messages from elsewhere in the program. The problem is, the `TypedSocketSender` still takes messages of the top-level protocol type, so e.g. the heartbeat sender needs to construct a `MessageToDrone` even though it only wants to send messages of the `MessageToDrone::Heartbeat` variant.

This PR changes `TypedSocketSender` so that it holds a boxed callback for converting an input into the type that needs to be sent on the wire. For example, instead of the old way:

```rust
let sender = conn.sender();
sender.send(MessageFromDrone::Heartbeat(Heartbeat {...}));
```

We now have

```rust
let sender = conn.sender(MessageFromDrone::Heartbeat);
sender.send(Heartbeat {...});
```