### PR TITLE
Move cli into main plane binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `dev/cli.sh` script runs the Plane CLI, configured to connect to the local P
 
 ```bash
 dev/cli.sh connect \
+    --wait \
     --cluster 'localhost:9090' \
     --image ghcr.io/drifting-in-space/demo-image-drop-four
 ```

--- a/dev/cli.sh
+++ b/dev/cli.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cargo -q run --bin cli -- --controller http://localhost:8080 "$@"
+cargo -q run -- admin --controller http://localhost:8080 "$@"

--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod admin;
 pub mod client;
 pub mod controller;
 pub mod database;

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
+use plane::admin::AdminOpts;
 use plane::client::PlaneClient;
 use plane::controller::run_controller;
 use plane::database::connect_and_migrate;
@@ -104,6 +105,7 @@ enum Command {
         #[clap(long)]
         db: String,
     },
+    Admin(AdminOpts),
 }
 
 async fn run(opts: Opts) -> Result<()> {
@@ -235,6 +237,9 @@ async fn run(opts: Opts) -> Result<()> {
             tracing::info!("Starting DNS server");
             let client = PlaneClient::new(controller_url);
             run_dns(name, client, port).await?;
+        }
+        Command::Admin(admin_opts) => {
+            plane::admin::run_admin_command(admin_opts).await;
         }
     }
 

--- a/plane/src/proxy/cert_pair.rs
+++ b/plane/src/proxy/cert_pair.rs
@@ -131,7 +131,7 @@ impl CertificatePair {
         // If the file does not exist, we want to make sure it is created with specific
         // permissions instead of the default system umask.
         if !path.exists() {
-            std::fs::File::create(&path)?;
+            std::fs::File::create(path)?;
             let permissions = Permissions::from_mode(0o600);
             std::fs::set_permissions(path, permissions)?;
         }


### PR DESCRIPTION
This moves the cli from a separate binary to the `plane admin` subcommand. The main advantage of this is that it allows us to ship one docker image that can be used both to run controllers/nodes/proxies and also to run admin commands.