### PR TITLE
Remove 'preview' from image name

### DIFF
--- a/.github/workflows/plane2-build-image.yml
+++ b/.github/workflows/plane2-build-image.yml
@@ -2,12 +2,12 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [ "plane-preview" ]
+    branches: [ "plane2-preview" ]
     tags: [ 'v*.*.*' ]
     paths-ignore: [ "/docs" ]
 
   pull_request:
-    branches: [ "plane-preview" ]
+    branches: [ "plane2-preview" ]
     paths:
     # Unless the Dockerfile itself has changed, testing whether a build passes
     # on a PR doesn’t tell us much that faster CI/CD workflows don’t already.
@@ -15,7 +15,7 @@ on:
     - 'docker/Dockerfile'
 
 env:
-  IMAGE_NAME: plane/plane-preview
+  IMAGE_NAME: plane/plane
 
 jobs:
   build:


### PR DESCRIPTION
This renames the docker image generated by the build from `plane/plane-preview` to `plane/plane`.