### PR TITLE
use docker for cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The Plane Controller will be available at http://localhost:8080, and the Plane P
 
 ### Connecting to a process
 
-The `dev/cli.sh` script runs the Plane CLI, configured to connect to the local Plane Controller.
+The `docker/cli.sh` script runs the Plane CLI, configured to connect to the local Plane Controller.
 
 ```bash
-dev/cli.sh connect \
+docker/cli.sh connect \
     --wait \
     --cluster 'localhost:9090' \
     --image ghcr.io/drifting-in-space/demo-image-drop-four

--- a/docker/cli.sh
+++ b/docker/cli.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker run -t --network docker_plane-dev \
+    plane/plane admin \
+    --controller http://plane-controller:8080 "$@"

--- a/docs/pages/quickstart-guide.mdx
+++ b/docs/pages/quickstart-guide.mdx
@@ -30,10 +30,8 @@ See the [architecture overview](concepts/architecture.mdx) for background on eac
 
 ### 3. Connect to a backend
 
-TODO: this part requires Rust; we should replace it with a Docker container.
-
 ```bash
-dev/cli.sh \
+docker/cli.sh \
     connect \
     --cluster 'localhost:9090' \
     --key 'my-first-backend' \
@@ -49,8 +47,8 @@ If no process is running, Plane will start one (provided that you supply an imag
 
 Here’s a breakdown of the command above:
 
-- `dev/cli.sh` is a lightweight shell script that runs the Plane CLI, pre-configuring it to point to
-  a Plane instance listening at `localhost:8080` (this corresponds to how the Docker Compose setup is configured).
+- `docker/cli.sh` is a shell script that runs the Plane CLI in a Docker container, pre-configuring it to point to
+  a Plane instance started in the Docker Compose file.
 - `connect` is the Plane CLI subcommand for issuing a “connect request”, which will return a URL that routes to
   a backend process.
 - `--cluster 'localhost:9090'` tells the CLI to start the backend on the `localhost:9090` cluster. Since the cluster name


### PR DESCRIPTION
Previously, following the tutorial required an install of rust/cargo and would build the CLI. This uses Docker for that part instead.