### PR TITLE
Fix docs repo base

### DIFF
--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -45,5 +45,6 @@ export default {
                 title: 'Plane – run WebSocket backends at scale'
             }
         }
-    }
+    },
+    docsRepositoryBase: 'https://github.com/drifting-in-space/plane/tree/main/docs',
 }


### PR DESCRIPTION
This is used to generate the “edit this page” links, which are currently broken.