### PR TITLE
Make controller IP nullable

### DIFF
--- a/plane/schema/derived_schema.sql
+++ b/plane/schema/derived_schema.sql
@@ -387,7 +387,7 @@ CREATE TABLE public.controller (
     is_online boolean NOT NULL,
     plane_version character varying(255) NOT NULL,
     plane_hash character varying(255) NOT NULL,
-    ip inet NOT NULL
+    ip inet
 );
 
 

--- a/plane/schema/migrations/20240105213756_make-controller-ip-nullable.sql
+++ b/plane/schema/migrations/20240105213756_make-controller-ip-nullable.sql
@@ -1,0 +1,1 @@
+alter table controller alter column ip drop not null;


### PR DESCRIPTION
The controller IP is set by `inet_client_addr()`, which can return `NULL` if postgres is connected to via a domain socket.

https://pgpedia.info/i/inet_client_addr.html