### PR TITLE
Allow bearer tokens in client, not just typed socket

### DIFF
--- a/plane/src/client/controller_address.rs
+++ b/plane/src/client/controller_address.rs
@@ -1,0 +1,54 @@
+use url::Url;
+
+/// An authorized address combines a URL with an optional bearer token.
+#[derive(Clone, Debug)]
+pub struct AuthorizedAddress {
+    pub url: Url,
+    pub bearer_token: Option<String>,
+}
+
+impl AuthorizedAddress {
+    pub fn join(&self, path: &str) -> AuthorizedAddress {
+        let url = self.url.clone();
+        let url = url.join(path).expect("URL is always valid");
+
+        Self {
+            url,
+            bearer_token: self.bearer_token.clone(),
+        }
+    }
+
+    pub fn to_websocket_address(mut self) -> AuthorizedAddress {
+        if self.url.scheme() == "http" {
+            self.url
+                .set_scheme("ws")
+                .expect("should always be able to set URL scheme to static value ws");
+        } else if self.url.scheme() == "https" {
+            self.url
+                .set_scheme("wss")
+                .expect("should always be able to set URL scheme to static value wss");
+        }
+
+        self
+    }
+
+    pub fn bearer_header(&self) -> Option<String> {
+        self.bearer_token
+            .as_ref()
+            .map(|token| format!("Bearer {}", token))
+    }
+}
+
+impl From<Url> for AuthorizedAddress {
+    fn from(url: Url) -> Self {
+        let bearer_token = match url.username() {
+            "" => None,
+            username => Some(username.to_string()),
+        };
+
+        let mut url = url;
+        url.set_username("").expect("URL is always valid");
+
+        Self { url, bearer_token }
+    }
+}

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -18,7 +18,7 @@ use axum::{
     routing::{get, post},
     Json, Router, Server,
 };
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
 use std::net::{SocketAddr, TcpListener};
 use tokio::{
     sync::oneshot::{self},
@@ -38,12 +38,19 @@ pub mod error;
 mod proxy;
 mod terminate;
 
-pub async fn status() -> Json<Value> {
-    Json(json!({
-        "status": "ok",
-        "version": PLANE_VERSION,
-        "hash": PLANE_GIT_HASH,
-    }))
+#[derive(Serialize, Deserialize)]
+pub struct StatusResponse {
+    pub status: String,
+    pub version: String,
+    pub hash: String,
+}
+
+pub async fn status() -> Json<StatusResponse> {
+    Json(StatusResponse {
+        status: "ok".to_string(),
+        version: PLANE_VERSION.to_string(),
+        hash: PLANE_GIT_HASH.to_string(),
+    })
 }
 
 struct HeartbeatSender {

--- a/plane/src/typed_socket/client.rs
+++ b/plane/src/typed_socket/client.rs
@@ -86,8 +86,7 @@ impl<T: ChannelMessage> TypedSocketConnector<T> {
     }
 }
 
-/// Turns a URL (which may have a token) into a request. If the URL contains a token, it is
-/// removed from the URL and turned into a bearer token Authorization header.
+/// Creates a WebSocket request from an AuthorizedAddress.
 fn auth_url_to_request(addr: &AuthorizedAddress) -> Result<hyper::Request<()>> {
     let mut request = hyper::Request::builder()
         .method(hyper::Method::GET)

--- a/plane/src/typed_socket/client.rs
+++ b/plane/src/typed_socket/client.rs
@@ -1,4 +1,5 @@
 use super::{ChannelMessage, Handshake, SocketAction, TypedSocket};
+use crate::client::controller_address::AuthorizedAddress;
 use crate::names::NodeName;
 use crate::{plane_version_info, util::ExponentialBackoff};
 use anyhow::{anyhow, Result};
@@ -8,20 +9,19 @@ use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tungstenite::handshake::client::generate_key;
 use tungstenite::{error::ProtocolError, Message};
-use url::Url;
 
 type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 pub struct TypedSocketConnector<T: ChannelMessage> {
-    pub url: Url,
+    authorized_address: AuthorizedAddress,
     backoff: ExponentialBackoff,
     _phantom: PhantomData<T>,
 }
 
 impl<T: ChannelMessage> TypedSocketConnector<T> {
-    pub fn new(url: Url) -> Self {
+    pub fn new(authorized_address: AuthorizedAddress) -> Self {
         Self {
-            url,
+            authorized_address,
             backoff: ExponentialBackoff::default(),
             _phantom: PhantomData,
         }
@@ -53,7 +53,7 @@ impl<T: ChannelMessage> TypedSocketConnector<T> {
             version: plane_version_info(),
         };
 
-        let req = auth_url_to_request(&self.url)?;
+        let req = auth_url_to_request(&self.authorized_address)?;
         let (mut socket, _) = tokio_tungstenite::connect_async(req).await?;
 
         socket
@@ -88,15 +88,14 @@ impl<T: ChannelMessage> TypedSocketConnector<T> {
 
 /// Turns a URL (which may have a token) into a request. If the URL contains a token, it is
 /// removed from the URL and turned into a bearer token Authorization header.
-fn auth_url_to_request(url: &Url) -> Result<hyper::Request<()>> {
-    let token = url.username().to_string();
-
+fn auth_url_to_request(addr: &AuthorizedAddress) -> Result<hyper::Request<()>> {
     let mut request = hyper::Request::builder()
         .method(hyper::Method::GET)
-        .uri(url.as_str())
+        .uri(addr.url.as_str())
         .header(
             "Host",
-            url.host_str()
+            addr.url
+                .host_str()
                 .ok_or_else(|| anyhow!("No host in URL."))?
                 .to_string(),
         )
@@ -105,11 +104,10 @@ fn auth_url_to_request(url: &Url) -> Result<hyper::Request<()>> {
         .header("Sec-WebSocket-Version", "13")
         .header("Sec-WebSocket-Key", generate_key());
 
-    if !token.is_empty() {
-        let token = data_encoding::BASE64.encode(token.as_bytes());
+    if let Some(bearer_header) = addr.bearer_header() {
         request = request.header(
             hyper::header::AUTHORIZATION,
-            hyper::header::HeaderValue::from_str(&format!("Bearer {}", token))?,
+            hyper::header::HeaderValue::from_str(&bearer_header)?,
         );
     }
 
@@ -187,23 +185,27 @@ async fn new_client<T: ChannelMessage>(
 
 #[cfg(test)]
 mod test {
+    use crate::client::controller_address::AuthorizedAddress;
+
     #[test]
     fn test_url_no_token() {
         let url = url::Url::parse("https://foo.bar.com/").unwrap();
-        let request = super::auth_url_to_request(&url).unwrap();
+        let addr = AuthorizedAddress::from(url);
+        let request = super::auth_url_to_request(&addr).unwrap();
         assert!(request.headers().get("Authorization").is_none());
     }
 
     #[test]
     fn test_url_with_token() {
         let url = url::Url::parse("https://abcdefg@foo.bar.com/").unwrap();
-        let request = super::auth_url_to_request(&url).unwrap();
+        let addr = AuthorizedAddress::from(url);
+        let request = super::auth_url_to_request(&addr).unwrap();
         assert_eq!(
             request
                 .headers()
                 .get("Authorization")
                 .map(|d| d.to_str().unwrap()),
-            Some("Bearer YWJjZGVmZw==")
+            Some("Bearer abcdefg")
         );
         assert_eq!(
             request.headers().get("Host").map(|d| d.to_str().unwrap()),


### PR DESCRIPTION
Plane can be configured to use a bearer token by sending a connection string like `https://my-bearer-token@my-plane-controller.dev`. Previously, this was implemented in `TypedSocket` and so it only worked for WebSocket connections, not regular HTTP GET/POST requests.

This moves the logic into the client, allowing us to use the same code path for both regular and WebSocket requests.

This also removes base64-encoding from the conversion step. base64-encoding is typically used in `Basic` auth, but not `Bearer` auth.