### PR TITLE
adds tracing spans to tracing_subscriber capture

### DIFF
--- a/plane/src/init_tracing.rs
+++ b/plane/src/init_tracing.rs
@@ -1,14 +1,17 @@
 use tracing_subscriber::{
-    filter::LevelFilter, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt,
-    EnvFilter,
+    filter::LevelFilter, fmt::format::FmtSpan, prelude::__tracing_subscriber_SubscriberExt,
+    util::SubscriberInitExt, EnvFilter,
 };
 
 pub fn init_tracing() {
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
+
+    let layer = tracing_subscriber::fmt::layer().with_span_events(FmtSpan::FULL);
+
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
+        .with(layer)
         .with(filter)
         .init();
 }


### PR DESCRIPTION
This is useful because it means the #[tracing::instrument] decoration on some thing immediately shows up in logs.

Otherwise it only shows up alongside a tracing event (info!, debug! etc)