### PR TITLE
Bump name length

### DIFF
--- a/plane/src/names.rs
+++ b/plane/src/names.rs
@@ -2,7 +2,7 @@ use crate::types::NodeKind;
 use clap::error::ErrorKind;
 use std::fmt::{Debug, Display};
 
-const MAX_NAME_LENGTH: usize = 30;
+const MAX_NAME_LENGTH: usize = 45;
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum NameError {


### PR DESCRIPTION
When deployed on EC2, drones and proxies have two unique identifiers: the plane-side identifier and the EC2 instance ID. Rather than creating a random ID for plane and then having to look up the association between plane-side ID and EC2 instance ID, it is preferable to derive one from the other.

We have no control over the EC2 instance ID, so the only way to associate the two is to generate the Plane-side node ID from the instance ID.

The instance ID generated by EC2 is 19 characters long. The prefix Plane applies is two characters long. If we want to add information about the cluster and environment (stg/prod/etc.) to the name, we need another three hyphens. That leaves only 6 characters remaining for both the name of the cluster and environment. This PR gives us a bit more breathing room.

Note that even though we encode the instance ID in the node name, this is just a convenience for human users; we should not extract this string from the ID to connect to it.