### PR TITLE
Support suffix for DNS server

### DIFF
--- a/docs/pages/deploy-to-prod.mdx
+++ b/docs/pages/deploy-to-prod.mdx
@@ -121,8 +121,9 @@ Obtaining a certificate involves proving to a third party that you control the d
 Plane implements the [ACME DNS-01](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) challenge type to obtain a TLS
 certificate for each proxy. Each proxy generates its own private key, which never leaves that proxy.
 
-For this to work, the `NS` record for the `_acme-challenge.<cluster name>` subdomain needs to point to one or more Plane DNS servers.
-These are basic DNS servers that exist only to serve the ACME DNS-01 challenge.
+For this to work, the `CNAME` record for the `_acme-challenge.<cluster name>` subdomain needs to point to a domain like
+`<cluster name>.my-dns-acme-server.com`. The `A` record of `<cluster name>.my-dns-acme-server.com` needs to contain the public
+IP of a DNS server that is running the Plane ACME DNS-01 receiver, with port 53 (TCP and UDP) open to the public internet.
 
-The DNS servers need to be able to accept incoming connections from the public internet on port 53 (both UDP and TCP).
-
+These are basic DNS servers that exist only to serve the ACME DNS-01 challenge, which is required for proxies to update their
+certificates.

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -125,7 +125,9 @@ impl TestEnvironment {
         let port = listener.local_addr().unwrap().port();
         let name = AcmeDnsServerName::new_random();
         let handle = tokio::spawn(async move {
-            run_dns_with_listener(name, client, listener).await.unwrap();
+            run_dns_with_listener(name, client, listener, None)
+                .await
+                .unwrap();
         });
 
         DnsServer {

--- a/plane/src/dns/name_to_cluster.rs
+++ b/plane/src/dns/name_to_cluster.rs
@@ -1,0 +1,94 @@
+use std::str::FromStr;
+
+use crate::types::ClusterName;
+
+/// Maps a requested domain name to a cluster name.
+///
+/// This can be configured to operate in two ways.
+///
+/// If the `cname_zone` is `None`, the server assumes that it is the authoritative
+/// DNS server for the cluster. It expects requests of the form
+/// _acme-challenge.<cluster name>, and will strip the _acme-challenge prefix.
+///
+/// If the `cname_zone` is `Some(_)`, the server will expect requests of the form
+/// <cluster name>.<cname_zone>, and will strip the <cname_zone> suffix.
+///
+/// Note that the _acme-challenge. prefix is not expected in the case where
+/// `cname_zone` is `Some(_)`. The _acme-challenge record should be pointed
+/// directly to the <cluster name>.<cname_zone> record via a CNAME record.
+///
+/// In production, the `cname_zone` should always be set (and the CLI enforces
+/// this), but for testing it is useful to be able to run without a `cnbame_zone`
+pub struct NameToCluster {
+    cname_zone: Option<String>,
+}
+
+impl NameToCluster {
+    pub fn new(cname_zone: Option<String>) -> Self {
+        Self { cname_zone }
+    }
+
+    pub fn cluster_name(&self, name: &str) -> Option<ClusterName> {
+        let name = name.strip_suffix('.').unwrap_or(name);
+
+        match &self.cname_zone {
+            Some(cname_zone) => {
+                let name = name.strip_suffix(cname_zone)?;
+                let name = name.strip_suffix('.').unwrap_or(name);
+                ClusterName::from_str(name).ok()
+            }
+            None => {
+                let name = name.strip_prefix("_acme-challenge.")?;
+                ClusterName::from_str(name).ok()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::types::ClusterName;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_no_cname_zone() {
+        let name_to_cluster = super::NameToCluster::new(None);
+
+        assert_eq!(
+            name_to_cluster.cluster_name("foo.bar.baz"),
+            None,
+            "No cluster name should be returned for a domain without a _acme-challenge prefix."
+        );
+
+        assert_eq!(
+            name_to_cluster.cluster_name("_acme-challenge.foo.bar.baz"),
+            Some(ClusterName::from_str("foo.bar.baz").unwrap())
+        );
+
+        assert_eq!(
+            name_to_cluster.cluster_name("_acme-challenge.foo.bar.baz."),
+            Some(ClusterName::from_str("foo.bar.baz").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_cname_zone() {
+        let name_to_cluster = super::NameToCluster::new(Some("example.com".to_string()));
+
+        assert_eq!(
+            name_to_cluster.cluster_name("foo.bar.baz"),
+            None,
+            "No match for a domain that lacks the cname zone."
+        );
+
+        assert_eq!(
+            name_to_cluster.cluster_name("foo.bar.baz.example.com"),
+            Some(ClusterName::from_str("foo.bar.baz").unwrap())
+        );
+
+        assert_eq!(
+            name_to_cluster.cluster_name("foo.bar.baz.example.com."),
+            Some(ClusterName::from_str("foo.bar.baz").unwrap())
+        );
+    }
+}

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -100,13 +100,13 @@ enum Command {
 
         /// Suffix to strip from requests before looking up TXT records.
         /// E.g. if the zone is "example.com", a TXT record lookup
-        /// for _acme-challenge.foo.bar.baz.example.com
+        /// for foo.bar.baz.example.com
         /// will return the TXT records for the cluster "foo.bar.baz".
         ///
-        /// The DNS record for foo.bar.baz in this case should have a CNAME
-        /// record pointing to this DNS server.
+        /// The DNS record for _acme-challenge.foo.bar.baz in this case
+        /// should have a CNAME record pointing to foo.bar.baz.example.com.
         #[clap(long)]
-        zone: Option<String>,
+        zone: String,
 
         #[clap(long, default_value = "53")]
         port: u16,
@@ -247,7 +247,7 @@ async fn run(opts: Opts) -> Result<()> {
             let name = name.or_random();
             tracing::info!("Starting DNS server");
             let client = PlaneClient::new(controller_url);
-            run_dns(name, client, port, zone).await?;
+            run_dns(name, client, port, Some(zone)).await?;
         }
         Command::Admin(admin_opts) => {
             plane::admin::run_admin_command(admin_opts).await;

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -98,6 +98,16 @@ enum Command {
         #[clap(long)]
         controller_url: Url,
 
+        /// Suffix to strip from requests before looking up TXT records.
+        /// E.g. if the zone is "example.com", a TXT record lookup
+        /// for _acme-challenge.foo.bar.baz.example.com
+        /// will return the TXT records for the cluster "foo.bar.baz".
+        ///
+        /// The DNS record for foo.bar.baz in this case should have a CNAME
+        /// record pointing to this DNS server.
+        #[clap(long)]
+        zone: Option<String>,
+
         #[clap(long, default_value = "53")]
         port: u16,
     },
@@ -232,11 +242,12 @@ async fn run(opts: Opts) -> Result<()> {
             name,
             controller_url,
             port,
+            zone,
         } => {
             let name = name.or_random();
             tracing::info!("Starting DNS server");
             let client = PlaneClient::new(controller_url);
-            run_dns(name, client, port).await?;
+            run_dns(name, client, port, zone).await?;
         }
         Command::Admin(admin_opts) => {
             plane::admin::run_admin_command(admin_opts).await;


### PR DESCRIPTION
This supports an optional DNS zone that can be provided to the DNS server. If a zone is provided, it will be stripped off of an incoming request before it is processed.

For example, if the server is started with `--zone example.com`, a request for `TXT` records on `_acme-challenge.foo.bar.baz.example.com` would be treated as a request for TXT records of the cluster `foo.bar.baz`.

If a zone is provided, requests that are not under that zone will fail.

This is useful because it allows us to use CNAME delegation for `_acme-challenge` subdomains.

For every cluster, the `_acme-challenge.[cluster name]` domain should have a CNAME record of `[cluster name].my.dns.server`. The A record for each of these records should point to the IP of the DNS server. The DNS server would be configured with `--zone my.dns.server`.

Background on CNAME delegation for DNS-01 challenges: https://www.eff.org/deeplinks/2018/02/technical-deep-dive-securing-automation-acme-dns-challenge-validation

TODO: do DNS providers typically support recursive wildcards on A requests? If not we may have to add them manually.