### PR TITLE
Fix clippy lints

### DIFF
--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -29,6 +29,18 @@ pub enum PlaneClientError {
 
     #[error("API error: {0} ({1})")]
     PlaneError(ApiError, StatusCode),
+
+    #[error("Failed to connect.")]
+    ConnectFailed(&'static str),
+
+    #[error("Bad configuration.")]
+    BadConfiguration(&'static str),
+
+    #[error("WebSocket error: {0}")]
+    Tungstenite(#[from] tokio_tungstenite::tungstenite::Error),
+
+    #[error("Send error")]
+    SendFailed,
 }
 
 #[derive(Clone)]

--- a/plane/src/typed_socket/mod.rs
+++ b/plane/src/typed_socket/mod.rs
@@ -1,3 +1,4 @@
+use crate::client::PlaneClientError;
 use crate::PlaneVersionInfo;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -66,8 +67,11 @@ impl<A: Debug> TypedSocketSender<A> {
 }
 
 impl<T: ChannelMessage> TypedSocket<T> {
-    pub async fn send(&mut self, message: T) -> anyhow::Result<()> {
-        self.send.send(SocketAction::Send(message)).await?;
+    pub async fn send(&mut self, message: T) -> Result<(), PlaneClientError> {
+        self.send
+            .send(SocketAction::Send(message))
+            .await
+            .map_err(|_| PlaneClientError::SendFailed)?;
         Ok(())
     }
 


### PR DESCRIPTION
Fixes clippy lints, mostly by extending the `PlaneClientError` type and using it instead of `unwraps` in the admin tool.