### PR TITLE
Add non-wildcard domain to certificate request

### DIFF
--- a/plane/src/proxy/cert_manager.rs
+++ b/plane/src/proxy/cert_manager.rs
@@ -322,7 +322,8 @@ async fn get_certificate(
     let account = builder.build().await.context("Building account")?;
 
     let mut builder = OrderBuilder::new(account);
-    builder.add_dns_identifier(format!("*.{}", cluster));
+    builder.add_dns_identifier(format!("{}", cluster));
+    builder.add_dns_identifier(format!("*.{}", cluster)); // wildcard
     let order = builder.build().await.context("Building order")?;
 
     let authorizations = order


### PR DESCRIPTION
Currently, we obtain the certificate for wildcard domains only, which was ok before because we required subdomain routing. Now that we also allow path-only routing, we also want the cert to apply to the base domain itself.