### PR TITLE
Return status with connect response

### DIFF
--- a/plane/.sqlx/query-bb4d67150e3808a0b443ad0e1fd66b3b5f713518a772007b6caa85a86d12acf6.json
+++ b/plane/.sqlx/query-bb4d67150e3808a0b443ad0e1fd66b3b5f713518a772007b6caa85a86d12acf6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                backend_key.id as id,\n                backend_key.tag as tag,\n                backend_key.expires_at as expires_at,\n                backend_key.fencing_token as token,\n                backend_key.key_name as name,\n                now() as \"as_of!\"\n            from backend_key\n            left join backend on backend_key.id = backend.id\n            where backend_key.key_name = $1\n            and backend_key.namespace = $2\n            ",
+  "query": "\n            select\n                backend_key.id as id,\n                backend_key.tag as tag,\n                backend_key.expires_at as expires_at,\n                backend_key.fencing_token as token,\n                backend_key.key_name as name,\n                backend.last_status as status,\n                now() as \"as_of!\"\n            from backend_key\n            left join backend on backend_key.id = backend.id\n            where backend_key.key_name = $1\n            and backend_key.namespace = $2\n            ",
   "describe": {
     "columns": [
       {
@@ -30,6 +30,11 @@
       },
       {
         "ordinal": 5,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
         "name": "as_of!",
         "type_info": "Timestamptz"
       }
@@ -46,8 +51,9 @@
       false,
       false,
       false,
+      false,
       null
     ]
   },
-  "hash": "f77eb5db0c9b07ded9a515ef3593ca6883e8ac711bcf7c353d9d1d50747d676a"
+  "hash": "bb4d67150e3808a0b443ad0e1fd66b3b5f713518a772007b6caa85a86d12acf6"
 }

--- a/plane/plane-tests/tests/backend_status_in_response.rs
+++ b/plane/plane-tests/tests/backend_status_in_response.rs
@@ -1,0 +1,100 @@
+use crate::common::timeout::WithTimeout;
+use common::test_env::TestEnvironment;
+use plane::{
+    types::{BackendStatus, ConnectRequest, ExecutorConfig, PullPolicy, SpawnConfig},
+    types::{KeyConfig, ResourceLimits},
+};
+use plane_test_macro::plane_test;
+use serde_json::Map;
+use std::collections::HashMap;
+
+mod common;
+
+#[plane_test]
+async fn backend_status_in_response(env: TestEnvironment) {
+    let controller = env.controller().await;
+    let client = controller.client();
+    let _drone = env.drone(&controller).await;
+
+    // Wait for the drone to register. TODO: this seems long.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    tracing::info!("Requesting backend.");
+    let connect_request = ConnectRequest {
+        spawn_config: Some(SpawnConfig {
+            executable: ExecutorConfig {
+                image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
+                pull_policy: PullPolicy::IfNotPresent,
+                env: HashMap::default(),
+                resource_limits: ResourceLimits::default(),
+                credentials: None,
+            },
+            lifetime_limit_seconds: Some(5),
+            max_idle_seconds: None,
+        }),
+        key: Some(KeyConfig {
+            name: "reuse-key".to_string(),
+            namespace: "".to_string(),
+            tag: "".to_string(),
+        }),
+        user: None,
+        auth: Map::default(),
+    };
+
+    let response = client
+        .connect(&env.cluster, &connect_request)
+        .await
+        .unwrap();
+    tracing::info!("Got response.");
+
+    assert!(response.spawned);
+    assert_eq!(response.status, BackendStatus::Scheduled);
+
+    let backend_id = response.backend_id.clone();
+
+    let mut backend_status_stream = client
+        .backend_status_stream(&env.cluster, &backend_id)
+        .with_timeout(10)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Wait for two status updates.
+    for _ in 0..2 {
+        let message = backend_status_stream
+            .next()
+            .with_timeout(10)
+            .await
+            .unwrap()
+            .unwrap();
+
+        tracing::info!(status=?message, "Got status");
+    }
+
+    let response2 = client
+        .connect(&env.cluster, &connect_request)
+        .await
+        .unwrap();
+
+    assert!(!response2.spawned);
+    assert_eq!(response2.backend_id, backend_id);
+    assert_ne!(
+        response2.status,
+        BackendStatus::Scheduled,
+        "Backend status should have changed."
+    );
+
+    loop {
+        let message = backend_status_stream
+            .next()
+            .with_timeout(10)
+            .await
+            .unwrap()
+            .unwrap();
+
+        tracing::info!("Got status: {:?}", message);
+        if message.status == BackendStatus::Terminated {
+            break;
+        }
+    }
+}

--- a/plane/src/database/connect.rs
+++ b/plane/src/database/connect.rs
@@ -210,6 +210,7 @@ async fn attempt_connect(
                     key_result.id,
                     cluster,
                     false,
+                    key_result.status,
                     token,
                     secret_token,
                     client,
@@ -259,8 +260,15 @@ async fn attempt_connect(
     )
     .await?;
 
-    let connect_response =
-        ConnectResponse::new(backend_id, cluster, true, token, secret_token, client);
+    let connect_response = ConnectResponse::new(
+        backend_id,
+        cluster,
+        true,
+        BackendStatus::Scheduled,
+        token,
+        secret_token,
+        client,
+    );
 
     Ok(connect_response)
 }

--- a/plane/src/types.rs
+++ b/plane/src/types.rs
@@ -380,6 +380,8 @@ pub struct ConnectResponse {
     /// Whether the backend is a new one spawned due to the request.
     pub spawned: bool,
 
+    pub status: BackendStatus,
+
     pub token: BearerToken,
 
     pub url: String,
@@ -394,6 +396,7 @@ impl ConnectResponse {
         backend_id: BackendName,
         cluster: &ClusterName,
         spawned: bool,
+        status: BackendStatus,
         token: BearerToken,
         secret_token: SecretToken,
         client: &PlaneClient,
@@ -409,6 +412,7 @@ impl ConnectResponse {
         Self {
             backend_id,
             spawned,
+            status,
             token,
             url,
             secret_token,


### PR DESCRIPTION
- Adds a field `status` to a `ConnectResponse`:
  - When a backend is newly spawned, it takes on the value `BackendStatus::Scheduled`
  - When a backend already exists, it takes on the last status from the database