### PR TITLE
Make controller heartbeats ephemeral

### DIFF
--- a/plane/plane-tests/tests/controller_status.rs
+++ b/plane/plane-tests/tests/controller_status.rs
@@ -1,6 +1,4 @@
 use common::test_env::TestEnvironment;
-use common::timeout::WithTimeout;
-use plane::database::{controller::ControllerHeartbeatNotification, subscribe::Subscription};
 use plane_test_macro::plane_test;
 
 mod common;
@@ -15,34 +13,19 @@ async fn controller_status_returns(env: TestEnvironment) {
 #[plane_test]
 async fn controller_registers_itself(env: TestEnvironment) {
     let db = env.db().await;
-    let mut listener: Subscription<ControllerHeartbeatNotification> = db.subscribe();
     let mut controller = env.controller().await;
 
-    let heartbeat = listener
-        .next()
-        .with_timeout(10)
-        .await
-        .expect("Did not receive first heartbeat message.")
-        .unwrap();
-    assert_eq!(&heartbeat.payload.id, controller.id());
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    let online_controllers = db.controller().online_controllers().await.unwrap();
-
-    assert_eq!(online_controllers.len(), 1);
-    assert_eq!(&online_controllers[0].id, controller.id());
+    let controllers = db.controller().online_controllers().await.unwrap();
+    assert_eq!(1, controllers.len());
+    assert_eq!(controller.id(), &controllers[0].id);
 
     // Stop the controller.
     controller.terminate().await;
 
-    // Expect an "offline" heartbeat.
-    let heartbeat = listener
-        .next()
-        .with_timeout(10)
-        .await
-        .expect("Did not receive second heartbeat message.")
-        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    assert!(!heartbeat.payload.is_online);
     let online_controllers = db.controller().online_controllers().await.unwrap();
     assert_eq!(online_controllers.len(), 0);
 }

--- a/plane/src/database/controller.rs
+++ b/plane/src/database/controller.rs
@@ -1,27 +1,13 @@
-use super::subscribe::emit;
 use crate::names::ControllerName;
 use crate::PLANE_GIT_HASH;
 use crate::PLANE_VERSION;
 use anyhow::Result;
 use chrono::DateTime;
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
 pub struct ControllerDatabase<'a> {
     pool: &'a PgPool,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ControllerHeartbeatNotification {
-    pub id: ControllerName,
-    pub is_online: bool,
-}
-
-impl super::subscribe::NotificationPayload for ControllerHeartbeatNotification {
-    fn kind() -> &'static str {
-        "controller_heartbeat"
-    }
 }
 
 impl<'a> ControllerDatabase<'a> {
@@ -52,15 +38,6 @@ impl<'a> ControllerDatabase<'a> {
             PLANE_GIT_HASH,
         )
         .execute(&mut *transaction)
-        .await?;
-
-        emit(
-            &mut *transaction,
-            &ControllerHeartbeatNotification {
-                id: name.clone(),
-                is_online,
-            },
-        )
         .await?;
 
         transaction.commit().await?;


### PR DESCRIPTION
We have been emitting a "heartbeat" message, which gets stored in the `event` table. But it's only used for tests, and adds a bunch of machinery. This removes it for a simpler (though admittedly uglier) sleep in the tests.