### PR TITLE
[docs] Fix typo in cargo nextest install instructions

### DIFF
--- a/docs/pages/developing.mdx
+++ b/docs/pages/developing.mdx
@@ -61,7 +61,7 @@ is possible to run them with `cargo test --all`, it is better to ues a test runn
 supports parallel execution. To install `nextest`, run:
 
 ```bash
-cargo install nextest
+cargo install cargo-nextest
 ```
 
 Then, to run the tests, run:


### PR DESCRIPTION
[`nextest`](https://crates.io/crates/nextest) appears to be a real (but empty) crate. Replaced with the intended `cargo-nextest`.