### PR TITLE
Document Mac docker setting prereq for local dev

### DIFF
--- a/docs/pages/developing.mdx
+++ b/docs/pages/developing.mdx
@@ -17,6 +17,9 @@ Rust and Docker installed.
 Follow [these instructions](https://www.rust-lang.org/tools/install) to install Rust, and
 [these instructions](https://docs.docker.com/get-docker/) to install Docker.
 
+If on Mac OS, ensure "Allow the default Docker socket to be used" is enabled in Docker Desktop
+(Settings > Advanced).
+
 ## Running locally
 
 The [quickstart guide](quickstart-guide.mdx) describes a simple way to run Plane locally


### PR DESCRIPTION
Without "Allow the default Docker socket to be used" (not on by default), drone was having trouble connecting to docker on Mac OS:

```
$ ./dev/drone.sh 

[...]

ERROR plane::drone::docker: Error receiving Docker event. e=HyperResponseError { err: hyper::Error(Connect, Os { code: 2, kind: NotFound, message: "No such file or directory" }) }
```
