### PR TITLE
Add error kind

### DIFF
--- a/plane/src/controller/connect.rs
+++ b/plane/src/controller/connect.rs
@@ -1,4 +1,4 @@
-use super::error::err_to_response;
+use super::error::{err_to_response, ApiErrorKind};
 use super::Controller;
 use crate::database::connect::ConnectError;
 use crate::types::{ConnectRequest, ConnectResponse};
@@ -11,46 +11,55 @@ fn connect_error_to_response(connect_error: &ConnectError) -> Response {
             connect_error,
             StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to acquire lock.",
+            ApiErrorKind::FailedToAcquireKey,
         ),
         ConnectError::KeyUnheldNoSpawnConfig => err_to_response(
             connect_error,
             StatusCode::CONFLICT,
             "Lock is unheld but no spawn config was provided.",
+            ApiErrorKind::KeyUnheldNoSpawnConfig,
         ),
         ConnectError::KeyHeldUnhealthy => err_to_response(
             connect_error,
             StatusCode::INTERNAL_SERVER_ERROR,
             "Lock is held but unhealthy.",
+            ApiErrorKind::KeyHeldUnhealthy,
         ),
         ConnectError::KeyHeld { .. } => err_to_response(
             connect_error,
             StatusCode::CONFLICT,
             "Lock is held but tag does not match.",
+            ApiErrorKind::KeyHeld,
         ),
         ConnectError::NoDroneAvailable => err_to_response(
             connect_error,
             StatusCode::INTERNAL_SERVER_ERROR,
             "No active drone available.",
+            ApiErrorKind::NoDroneAvailable,
         ),
         ConnectError::FailedToRemoveKey => err_to_response(
             connect_error,
             StatusCode::CONFLICT,
             "Failed to remove lock.",
+            ApiErrorKind::FailedToRemoveKey,
         ),
-        ConnectError::Sql(_) | ConnectError::Serialization(_) => err_to_response(
+        ConnectError::DatabaseError(_) | ConnectError::Serialization(_) => err_to_response(
             connect_error,
             StatusCode::INTERNAL_SERVER_ERROR,
             "Internal error.",
+            ApiErrorKind::Other,
         ),
         ConnectError::NoClusterProvided => err_to_response(
             connect_error,
             StatusCode::BAD_REQUEST,
             "No cluster provided, and no default cluster for this controller.",
+            ApiErrorKind::NoClusterProvided,
         ),
         ConnectError::Other(_) => err_to_response(
             connect_error,
             StatusCode::INTERNAL_SERVER_ERROR,
             "Internal error.",
+            ApiErrorKind::Other,
         ),
     }
 }

--- a/plane/src/controller/drone.rs
+++ b/plane/src/controller/drone.rs
@@ -1,4 +1,4 @@
-use super::Controller;
+use super::{error::ApiErrorKind, Controller};
 use crate::{
     controller::error::IntoApiError,
     database::{
@@ -214,10 +214,11 @@ pub async fn handle_drone_socket(
     connect_info: ConnectInfo<SocketAddr>,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Response> {
-    let cluster: ClusterName = cluster
-        .parse()
-        .ok()
-        .or_status(StatusCode::BAD_REQUEST, "Invalid cluster name")?;
+    let cluster: ClusterName = cluster.parse().ok().or_status(
+        StatusCode::BAD_REQUEST,
+        "Invalid cluster name",
+        ApiErrorKind::InvalidClusterName,
+    )?;
     let ip = connect_info.0.ip();
     Ok(ws.on_upgrade(move |socket| drone_socket(cluster, socket, controller, ip)))
 }

--- a/plane/src/controller/proxy.rs
+++ b/plane/src/controller/proxy.rs
@@ -1,4 +1,4 @@
-use super::Controller;
+use super::{error::ApiErrorKind, Controller};
 use crate::{
     controller::error::IntoApiError,
     protocol::{
@@ -132,10 +132,11 @@ pub async fn handle_proxy_socket(
     connect_info: ConnectInfo<SocketAddr>,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, Response> {
-    let cluster: ClusterName = cluster
-        .parse()
-        .ok()
-        .or_status(StatusCode::BAD_REQUEST, "Invalid cluster name")?;
+    let cluster: ClusterName = cluster.parse().ok().or_status(
+        StatusCode::BAD_REQUEST,
+        "Invalid cluster name",
+        ApiErrorKind::InvalidClusterName,
+    )?;
     let ip = connect_info.ip();
     Ok(ws.on_upgrade(move |socket| proxy_socket(cluster, socket, controller, ip)))
 }

--- a/plane/src/database/connect.rs
+++ b/plane/src/database/connect.rs
@@ -50,7 +50,7 @@ pub enum ConnectError {
     FailedToAcquireKey,
 
     #[error("SQL error: {0}")]
-    Sql(#[from] sqlx::Error),
+    DatabaseError(#[from] sqlx::Error),
 
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),


### PR DESCRIPTION
Adds an error kind type.

There's probably some refactoring to do here, e.g. the `StatusCode` could be determined by adding a `status()` method to the `ApiErrorKind` itself. But I wanted to focus on getting the change to the message interface in for now; that way we can refactor the code later without worrying about breaking the interface.