### PR TITLE
Make `--wait` the default for `connect` and `terminate`

### DIFF
--- a/docs/pages/quickstart-guide.mdx
+++ b/docs/pages/quickstart-guide.mdx
@@ -36,7 +36,6 @@ docker/cli.sh \
     --cluster 'localhost:9090' \
     --key 'my-first-backend' \
     --image 'ghcr.io/drifting-in-space/demo-image-drop-four' \
-    --wait
 ```
 
 You can think of Plane as a big key-value store that associates “keys” (arbitrary strings) with running processes
@@ -60,8 +59,6 @@ Here’s a breakdown of the command above:
   to that backend process.
 - `--image '...'` tells the CLI that if it needs to start a new backend process,
   it should use the given Docker image. In this case, the image serves a simple turn-based multiplayer game.
-- `--wait` tells the CLI to display the backend’s status as it starts up, and to wait until the backend is `Ready` before
-  returning.
 
 <Callout type="info">
   At least one of `--key` or `--image` must be provided, but it is not necessary to include both.

--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -97,7 +97,7 @@ enum AdminCommand {
         key: Option<String>,
 
         #[clap(long)]
-        wait: bool,
+        immediate: bool,
 
         /// The number of seconds without any connected clients to wait before terminating the backend.
         #[clap(long)]
@@ -116,7 +116,7 @@ enum AdminCommand {
         hard: bool,
 
         #[clap(long)]
-        wait: bool,
+        immediate: bool,
     },
     Drain {
         #[clap(long)]
@@ -147,7 +147,7 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
             cluster,
             image,
             key,
-            wait,
+            immediate,
             max_idle_seconds,
             id,
         } => {
@@ -191,7 +191,7 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
                 println!("Drone: {}", drone.to_string().bright_green());
             }
 
-            if wait {
+            if !immediate {
                 let mut stream = client.backend_status_stream(&response.backend_id).await?;
 
                 while let Some(status) = stream.next().await {
@@ -210,7 +210,7 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
         AdminCommand::Terminate {
             backend,
             hard,
-            wait,
+            immediate,
         } => {
             if hard {
                 client.hard_terminate(&backend).await?
@@ -223,7 +223,7 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
                 backend.to_string().bright_green()
             );
 
-            if wait {
+            if !immediate {
                 let mut stream = client.backend_status_stream(&backend).await?;
 
                 while let Some(status) = stream.next().await {


### PR DESCRIPTION
Currently, CLI commands `connect` and `terminate` require you to specify `--wait` if you want them to wait. This should be the default, and `--immediate` should be provided for the current default behavior.

Fixes #589

Merge prerequisites
===================

- [x] Tests must pass, including integration tests. See [Developing Plane)(../developing.mdx) for instructions on running tests.

- [x] Clippy should not identify new issues. Run cargo clippy to check this.

- [x] The code must be formatted. Run cargo fmt to format it in-place.

- [x] The plane2/schema/derived_schema.sql file must reflect all migrations. If your PR adds a migration, run plane2/schema/prepare.sh (see DB Migrations).

Test Plan
=========
Tested for expected behavior change in the CLI.

Setup:
------
In different terminals, run:

```bash
$ ./dev/postgres.sh && ./dev/controller.sh
```

```bash
$ ./dev/drone.sh
```

```bash
$ ./dev/proxy.sh
```

Previous behavior
-----------------
Default behavior of `connect`:
```bash
$ ./dev/cli.sh connect --cluster 'localhost:9090' --key 'my-first-backend' --image 'ghcr.io/drifting-in-space/demo-image-drop-four'
Created backend: xg8rilbuvssw0o
URL: http://localhost:9090/A8mxZ49t_H47v44w25h-Sy-5lLfScnEqlnGCwAcLick/
Status URL: http://127.0.0.1:8080/pub/b/xg8rilbuvssw0o/status
Drone: dr-ks68bkvrdmx2kn
```

Default behavior of `terminate`:
```bash
$ ./dev/cli.sh terminate --backend xg8rilbuvssw0o
Sent termination signal xg8rilbuvssw0o
```

Using `--wait` with `connect`:
```bash
$ ./dev/cli.sh connect --cluster 'localhost:9090' --key 'my-first-backend' --image 'ghcr.io/drifting-in-space/demo-image-drop-four' --wait
Created backend: balksc55gs2890
URL: http://localhost:9090/GRkqL_X8u6aLoHindBo8yKOIeSyHs1_FX8hgXlLsJZA/
Status URL: http://127.0.0.1:8080/pub/b/balksc55gs2890/status
Drone: dr-ks68bkvrdmx2kn
Status: scheduled at 2024-02-05 19:38:38.588 UTC
Status: loading at 2024-02-05 19:38:38.593 UTC
Status: starting at 2024-02-05 19:38:38.599 UTC
Status: waiting at 2024-02-05 19:38:38.901 UTC
Status: ready at 2024-02-05 19:38:38.905 UTC
```

Using `--wait` with `terminate`:
```bash
$ ./dev/cli.sh terminate --backend balksc55gs2890 --wait
Sent termination signal balksc55gs2890
Status: scheduled at 2024-02-05 19:38:38.588 UTC
Status: loading at 2024-02-05 19:38:38.593 UTC
Status: starting at 2024-02-05 19:38:38.599 UTC
Status: waiting at 2024-02-05 19:38:38.901 UTC
Status: ready at 2024-02-05 19:38:38.905 UTC
Status: terminating at 2024-02-05 19:45:09.723 UTC
Status: terminated at 2024-02-05 19:45:19.846 UTC
```

New behavior
------------
Default behavior of `connect`:
```bash
$ ./dev/cli.sh connect --cluster 'localhost:9090' --key 'my-first-backend' --image 'ghcr.io/drifting-in-space/demo-image-drop-four'
Created backend: hnkn4i4eufhpxq
URL: http://localhost:9090/n7kYFN0ETXm7xLMj_P_Jf5R4Y2-Dq_E5q2DQ77mD7B8/
Status URL: http://127.0.0.1:8080/pub/b/hnkn4i4eufhpxq/status
Drone: dr-zlm6kze4phgvp4
Status: scheduled at 2024-02-05 19:57:54.230 UTC
Status: loading at 2024-02-05 19:57:54.240 UTC
Status: starting at 2024-02-05 19:57:54.246 UTC
Status: waiting at 2024-02-05 19:57:54.438 UTC
Status: ready at 2024-02-05 19:57:54.548 UTC
```

Default behavior of `terminate`:
```bash
$ ./dev/cli.sh terminate --backend hnkn4i4eufhpxq
Sent termination signal hnkn4i4eufhpxq
Status: scheduled at 2024-02-05 19:57:54.230 UTC
Status: loading at 2024-02-05 19:57:54.240 UTC
Status: starting at 2024-02-05 19:57:54.246 UTC
Status: waiting at 2024-02-05 19:57:54.438 UTC
Status: ready at 2024-02-05 19:57:54.548 UTC
Status: terminating at 2024-02-05 19:58:38.670 UTC
Status: terminated at 2024-02-05 19:58:39.089 UTC
```

Using `--immediate` with `connect`:
```bash
$ ./dev/cli.sh connect --cluster 'localhost:9090' --key 'my-first-backend' --image 'ghcr.io/drifting-in-space/demo-image-drop-four' --immediate
Created backend: faq6f4aoqgekba
URL: http://localhost:9090/lq-8j78RTKh2GCoU68TRNyv8or-ZhPMXVZjW17vKmvc/
Status URL: http://127.0.0.1:8080/pub/b/faq6f4aoqgekba/status
Drone: dr-zlm6kze4phgvp4
```

Using `--immediate` with `terminate`
```bash
$ ./dev/cli.sh terminate --backend faq6f4aoqgekba --immediate
Sent termination signal faq6f4aoqgekba
```

Documentation Changes
=====================
Found and removed the one mention I could find of `--wait` in the public docs:
```bash
$ rg -- --wait
docs/pages/quickstart-guide.mdx
39:    --wait
63:- `--wait` tells the CLI to display the backend’s status as it starts up, and to wait until the backend is `Ready` before
```

CLI help docs are auto-generated:
```bash
$ ./dev/cli.sh connect --help
Usage: plane admin --controller <CONTROLLER> connect [OPTIONS] --image <IMAGE>

Options:
      --cluster <CLUSTER>

      --image <IMAGE>

      --key <KEY>

      --immediate

      --max-idle-seconds <MAX_IDLE_SECONDS>
          The number of seconds without any connected clients to wait before terminating the backend
      --id <ID>
          An optional backend to assign the string (not recommended and may be removed. Omit to allow Plane to auto-assign one instead)
  -h, --help
          Print help

$ ./dev/cli.sh terminate --help
Usage: plane admin --controller <CONTROLLER> terminate [OPTIONS] --backend <BACKEND>

Options:
      --backend <BACKEND>
      --hard
      --immediate
  -h, --help               Print help
```