### PR TITLE
address issue when calling to_terminating() on an already-terminating state

### DIFF
--- a/docker/quickstart/supervisord.conf
+++ b/docker/quickstart/supervisord.conf
@@ -20,7 +20,7 @@ stderr_logfile=/var/log/plane-controller-stderr.log
 stdout_logfile=/var/log/plane-controller-stdout.log
 
 [program:plane-drone]
-command=/bin/plane drone --controller-url ws://localhost:8080 --cluster 'localhost:9090'
+command=/bin/plane drone --controller-url ws://localhost:8080 --ip 172.17.0.1 --cluster 'localhost:9090'
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/plane-drone-stderr.log

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -129,7 +129,10 @@ impl BackendState {
         reason: TerminationReason,
     ) -> BackendState {
         match self {
-            BackendState::Terminating { .. } | BackendState::Terminated { .. } => self.clone(),
+            BackendState::Terminating { .. } | BackendState::Terminated { .. } => {
+                tracing::warn!(?reason, ?termination, state=?self, "to_terminating called on terminating/terminated backend");
+                self.clone()
+            }
             _ => BackendState::Terminating {
                 last_status: self.status(),
                 termination,
@@ -140,7 +143,10 @@ impl BackendState {
 
     pub fn to_terminated(&self, exit_code: Option<i32>) -> BackendState {
         match self {
-            BackendState::Terminated { .. } => self.clone(),
+            BackendState::Terminated { .. } => {
+                tracing::warn!(?exit_code, state=?self, "to_terminated called on terminated backend");
+                self.clone()
+            }
             BackendState::Terminating {
                 last_status,
                 termination,

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -128,15 +128,19 @@ impl BackendState {
         termination: TerminationKind,
         reason: TerminationReason,
     ) -> BackendState {
-        BackendState::Terminating {
-            last_status: self.status(),
-            termination,
-            reason,
+        match self {
+            BackendState::Terminating { .. } | BackendState::Terminated { .. } => self.clone(),
+            _ => BackendState::Terminating {
+                last_status: self.status(),
+                termination,
+                reason,
+            },
         }
     }
 
     pub fn to_terminated(&self, exit_code: Option<i32>) -> BackendState {
         match self {
+            BackendState::Terminated { .. } => self.clone(),
             BackendState::Terminating {
                 last_status,
                 termination,


### PR DESCRIPTION
I'm seeing some `Terminating { last_status: Terminating, .. }` BackendStates. I think this is only possible if calling `to_terminating()` on an already-terminating status. This alters the `to_terminating()` and `to_terminated()` methods to return `self.clone()` if the state is already terminating or terminated since these methods should return states where the `last_status` is the last _alive_ status.

Also pushed a commit that fixes an issue with the Quickstart image on Linux where the drone can't reach the session backend containers. Maybe there's a more elegant solution, though? More info here: https://stackoverflow.com/questions/48546124/what-is-the-linux-equivalent-of-host-docker-internal