### PR TITLE
Add log config passthrough

### DIFF
--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -7,7 +7,7 @@ use plane::{
     controller::ControllerServer,
     database::PlaneDatabase,
     dns::run_dns_with_listener,
-    drone::Drone,
+    drone::{docker::PlaneDocker, Drone},
     names::{AcmeDnsServerName, ControllerName, DroneName, Name},
     proxy::AcmeEabConfiguration,
     types::ClusterName,
@@ -107,13 +107,15 @@ impl TestEnvironment {
         let connector = client.drone_connection(&TEST_CLUSTER.parse().unwrap());
         let docker = Docker::connect_with_local_defaults().unwrap();
         let db_path = self.scratch_dir.join("drone.db");
+
+        let docker = PlaneDocker::new(docker, None, None).await.unwrap();
+
         Drone::run(
             &DroneName::new_random(),
             connector,
             docker,
             Ipv4Addr::LOCALHOST.into(),
             Some(&db_path),
-            None,
         )
         .await
         .unwrap()

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -15,7 +15,7 @@ mod common;
 #[plane_test]
 async fn test_get_metrics(_: TestEnvironment) {
     let docker = bollard::Docker::connect_with_local_defaults().unwrap();
-    let plane_docker = PlaneDocker::new(docker, None).await.unwrap();
+    let plane_docker = PlaneDocker::new(docker, None, None).await.unwrap();
 
     // TODO: replace with locally built hello world
     plane_docker

--- a/plane/src/init_tracing.rs
+++ b/plane/src/init_tracing.rs
@@ -1,5 +1,5 @@
 use tracing_subscriber::{
-    filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter
+    filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
 };
 
 pub fn init_tracing() {

--- a/plane/src/init_tracing.rs
+++ b/plane/src/init_tracing.rs
@@ -1,6 +1,5 @@
 use tracing_subscriber::{
-    filter::LevelFilter, fmt::format::FmtSpan, prelude::__tracing_subscriber_SubscriberExt,
-    util::SubscriberInitExt, EnvFilter,
+    filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter
 };
 
 pub fn init_tracing() {
@@ -20,7 +19,7 @@ pub fn init_tracing() {
             .with(filter)
             .init();
     } else {
-        let layer = tracing_subscriber::fmt::layer().with_span_events(FmtSpan::FULL);
+        let layer = tracing_subscriber::fmt::layer();
 
         tracing_subscriber::registry()
             .with(layer)


### PR DESCRIPTION
- Adds a CLI flag for passing log config as JSON (`--log-config`)
- Passes the log config to Docker
- Some refactoring to pass `PlaneDocker` around instead of `Docker` plus `docker_runtime`, which allows us to pass the log config and makes some function signatures shorter.