### PR TITLE
remove stale lock announce messages (older than 1 hour)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -233,12 +233,16 @@ async fn main() -> Result<()> {
                         succeeded += 1;
                     }
                     if (failed + succeeded) % 10 == 0 {
-                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        println!(
+                            "Removed {:?} stale lock announce messages so far. ({:?} failed)",
+                            succeeded, failed
+                        );
                     }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
 
                 println!(
-                    "Successfully removed {:?} stale lock announce messages. ({:?} failed)",
+                    "Finished removing stale lock messages ({:?} succeeded, {:?} failed)",
                     succeeded, failed
                 );
             }


### PR DESCRIPTION
The World State stream grows unbounded since we aren't removing any lock announce messages. This adds functionality to the CLI's cleanup script to clean out lock announce messages that are older than 1 hour. Lock announce messages are only valid for 30 seconds, so 1 hour should be plenty of buffer.