### PR TITLE
Add plane cleanup loop

### DIFF
--- a/plane/.sqlx/query-7d4c92420e542e7086f81e00e16087bf8c2b29a618d7eab3cc7956a9ee456573.json
+++ b/plane/.sqlx/query-7d4c92420e542e7086f81e00e16087bf8c2b29a618d7eab3cc7956a9ee456573.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            delete from backend\n            where\n                last_status = $1\n                and now() - last_status_time > make_interval(days => $2)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7d4c92420e542e7086f81e00e16087bf8c2b29a618d7eab3cc7956a9ee456573"
+}

--- a/plane/.sqlx/query-ca6e40ee9cea913e0d6691eb375de7b7e4afe57f64fb00ae6d6bab3a6d2a6634.json
+++ b/plane/.sqlx/query-ca6e40ee9cea913e0d6691eb375de7b7e4afe57f64fb00ae6d6bab3a6d2a6634.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        delete from token\n        where expiration_time < now()\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "ca6e40ee9cea913e0d6691eb375de7b7e4afe57f64fb00ae6d6bab3a6d2a6634"
+}

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -96,6 +96,7 @@ impl TestEnvironment {
             ControllerName::new_random(),
             url,
             None,
+            None,
         )
         .await
         .expect("Unable to construct controller.");

--- a/plane/src/cleanup.rs
+++ b/plane/src/cleanup.rs
@@ -1,0 +1,36 @@
+use crate::database::PlaneDatabase;
+use anyhow::Result;
+
+const CLEANUP_LOOP_INTERVAL_SECONDS: u64 = 60 * 15;
+
+pub async fn run_cleanup(db: &PlaneDatabase, min_age_days: Option<i32>) -> Result<()> {
+    tracing::info!("Running cleanup");
+
+    if let Some(min_age_days) = min_age_days {
+        db.backend().cleanup(min_age_days).await?;
+    }
+
+    db.clean_up_tokens().await?;
+
+    tracing::info!("Done running cleanup");
+
+    Ok(())
+}
+
+pub async fn run_cleanup_loop(db: PlaneDatabase, min_age_days: Option<i32>) {
+    // Each controller runs a cleanup loop. To avoid having them all run at the same time, we
+    // introduce a random offset to the start time.
+    let random_offset_seconds = rand::random::<u64>() % CLEANUP_LOOP_INTERVAL_SECONDS;
+    tokio::time::sleep(tokio::time::Duration::from_secs(random_offset_seconds)).await;
+
+    loop {
+        if let Err(e) = run_cleanup(&db, min_age_days).await {
+            tracing::error!("Error running cleanup: {:?}", e);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            CLEANUP_LOOP_INTERVAL_SECONDS,
+        ))
+        .await;
+    }
+}

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -5,6 +5,7 @@ use self::{
     proxy::handle_proxy_socket,
 };
 use crate::{
+    cleanup,
     client::PlaneClient,
     controller::{connect::handle_connect, core::Controller, drone::handle_drone_socket},
     database::PlaneDatabase,
@@ -12,6 +13,7 @@ use crate::{
     names::ControllerName,
     signals::wait_for_shutdown_signal,
     types::ClusterName,
+    util::GuardHandle,
     PLANE_GIT_HASH, PLANE_VERSION,
 };
 use anyhow::Result;
@@ -107,6 +109,7 @@ pub struct ControllerServer {
     // server_handle is wrapped in an Option<> because we need to take ownership of it to join it
     // when gracefully terminating.
     server_handle: Option<JoinHandle<hyper::Result<()>>>,
+    _cleanup_handle: GuardHandle,
 }
 
 impl ControllerServer {
@@ -116,10 +119,19 @@ impl ControllerServer {
         id: ControllerName,
         controller_url: Url,
         default_cluster: Option<ClusterName>,
+        cleanup_min_age_days: Option<i32>,
     ) -> Result<Self> {
         let listener = TcpListener::bind(bind_addr)?;
 
-        Self::run_with_listener(db, listener, id, controller_url, default_cluster).await
+        Self::run_with_listener(
+            db,
+            listener,
+            id,
+            controller_url,
+            default_cluster,
+            cleanup_min_age_days,
+        )
+        .await
     }
 
     pub async fn run_with_listener(
@@ -128,8 +140,16 @@ impl ControllerServer {
         id: ControllerName,
         controller_url: Url,
         default_cluster: Option<ClusterName>,
+        cleanup_min_age_days: Option<i32>,
     ) -> Result<Self> {
         let bind_addr = listener.local_addr()?;
+
+        let cleanup_handle = {
+            let db = db.clone();
+            GuardHandle::new(async move {
+                cleanup::run_cleanup_loop(db.clone(), cleanup_min_age_days).await
+            })
+        };
 
         let (graceful_terminate_sender, graceful_terminate_receiver) =
             tokio::sync::oneshot::channel::<()>();
@@ -201,6 +221,7 @@ impl ControllerServer {
             server_handle: Some(server_handle),
             controller_id: id,
             bind_addr,
+            _cleanup_handle: cleanup_handle,
         })
     }
 
@@ -253,9 +274,17 @@ pub async fn run_controller(
     id: ControllerName,
     controller_url: Url,
     default_cluster: Option<ClusterName>,
+    cleanup_min_age_days: Option<i32>,
 ) -> Result<()> {
-    let mut server =
-        ControllerServer::run(db, bind_addr, id, controller_url, default_cluster).await?;
+    let mut server = ControllerServer::run(
+        db,
+        bind_addr,
+        id,
+        controller_url,
+        default_cluster,
+        cleanup_min_age_days,
+    )
+    .await?;
 
     wait_for_shutdown_signal().await;
 

--- a/plane/src/database/connect.rs
+++ b/plane/src/database/connect.rs
@@ -341,3 +341,19 @@ pub async fn connect(
         }
     }
 }
+
+pub async fn clean_up_tokens(pool: &PgPool) -> std::result::Result<(), sqlx::Error> {
+    let result = sqlx::query!(
+        r#"
+        delete from token
+        where expiration_time < now()
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    let row_count = result.rows_affected();
+    tracing::info!(row_count, "Cleaned up expired tokens");
+
+    Ok(())
+}

--- a/plane/src/database/mod.rs
+++ b/plane/src/database/mod.rs
@@ -91,6 +91,10 @@ impl PlaneDatabase {
         connect::connect(&self.pool, default_cluster, request, client).await
     }
 
+    pub async fn clean_up_tokens(&self) -> Result<(), sqlx::Error> {
+        connect::clean_up_tokens(&self.pool).await
+    }
+
     fn subscription_manager(&self) -> &EventSubscriptionManager {
         self.subscription_manager
             .get_or_init(|| EventSubscriptionManager::new(&self.pool))

--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod admin;
+pub mod cleanup;
 pub mod client;
 pub mod controller;
 pub mod database;

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -47,6 +47,9 @@ enum Command {
 
         #[clap(long)]
         default_cluster: Option<ClusterName>,
+
+        #[clap(long)]
+        cleanup_min_age_days: Option<i32>,
     },
     Drone {
         #[clap(long)]
@@ -141,6 +144,7 @@ async fn run(opts: Opts) -> Result<()> {
             db,
             controller_url,
             default_cluster,
+            cleanup_min_age_days,
         } => {
             let name = ControllerName::new_random();
 
@@ -157,7 +161,15 @@ async fn run(opts: Opts) -> Result<()> {
 
             let addr = (host, port).into();
 
-            run_controller(db, addr, name, controller_url, default_cluster).await?
+            run_controller(
+                db,
+                addr,
+                name,
+                controller_url,
+                default_cluster,
+                cleanup_min_age_days,
+            )
+            .await?
         }
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;


### PR DESCRIPTION
This adds a loop to the controller that runs ever 15 minutes and cleans up:
- old backends (only if configured with a maximum age)
- expired tokens

It also adds a dbcli command for doing this cleanup manually.