### PR TITLE
Pacify clippy

### DIFF
--- a/plane/src/drone/backend_manager.rs
+++ b/plane/src/drone/backend_manager.rs
@@ -165,6 +165,7 @@ impl Debug for BackendManager {
 }
 
 impl BackendManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         backend_id: BackendName,
         executor_config: ExecutorConfig,

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -137,14 +137,12 @@ impl PlaneDocker {
         static_token: Option<&BearerToken>,
     ) -> Result<SpawnResult> {
         run_container(
-            &self.docker,
+            self,
             backend_id,
             container_id,
             executable,
-            self.runtime.as_deref(),
             acquired_key,
             static_token,
-            self.log_config.as_ref(),
         )
         .await?;
         let port = get_port(&self.docker, container_id).await?;

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -332,6 +332,7 @@ pub struct ConnectResponse {
 }
 
 impl ConnectResponse {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         backend_id: BackendName,
         cluster: &ClusterName,


### PR DESCRIPTION
Clippy doesn't like long argument lists, we silence its warnings though a combination of shortening an argument list and telling clippy to be quiet where we don't (yet) want to.