### PR TITLE
only consider non-terminated and non-scheduled backends as termination candidates

### DIFF
--- a/plane/.sqlx/query-d0a47530eee694a2c3622050e484ad9f8a26f490cbc3924d2fad27b3f83bcfed.json
+++ b/plane/.sqlx/query-d0a47530eee694a2c3622050e484ad9f8a26f490cbc3924d2fad27b3f83bcfed.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                id as backend_id,\n                expiration_time,\n                allowed_idle_seconds,\n                last_keepalive,\n                now() as \"as_of!\"\n            from backend\n            where\n                drone_id = $1\n                and last_status != $2\n                and (\n                    now() - last_keepalive > make_interval(secs => allowed_idle_seconds)\n                    or now() > expiration_time\n                )\n            ",
+  "query": "\n            select\n                id as backend_id,\n                expiration_time,\n                allowed_idle_seconds,\n                last_keepalive,\n                now() as \"as_of!\"\n            from backend\n            where\n                drone_id = $1\n                and last_status not in ($2, $3)\n                and (\n                    now() - last_keepalive > make_interval(secs => allowed_idle_seconds)\n                    or now() > expiration_time\n                )\n            ",
   "describe": {
     "columns": [
       {
@@ -32,7 +32,8 @@
     "parameters": {
       "Left": [
         "Int4",
-        "Text"
+        "Varchar",
+        "Varchar"
       ]
     },
     "nullable": [
@@ -43,5 +44,5 @@
       null
     ]
   },
-  "hash": "44fe63d1578436e1b78fb40b499d5a0794441d8a8859bf43f31d6493aac7fded"
+  "hash": "d0a47530eee694a2c3622050e484ad9f8a26f490cbc3924d2fad27b3f83bcfed"
 }

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -411,13 +411,14 @@ impl<'a> BackendDatabase<'a> {
             from backend
             where
                 drone_id = $1
-                and last_status != $2
+                and last_status not in ($2, $3)
                 and (
                     now() - last_keepalive > make_interval(secs => allowed_idle_seconds)
                     or now() > expiration_time
                 )
             "#,
             drone_id.as_i32(),
+            BackendStatus::Scheduled.to_string(),
             BackendStatus::Terminated.to_string(),
         )
         .fetch_all(&self.db.pool)


### PR DESCRIPTION
When drones are overloaded, they may not be able to start a backend, so it gets stuck in a scheduled state. The controller sends termination requests to the drone to terminate the scheduled backend, the messages are acked, but the scheduled backends don't get set to "terminated". This changes the controller to only try sweeping backends that are non-scheduled and non-terminated.