### PR TITLE
add get_by_id() fn to the node database

### DIFF
--- a/plane/.sqlx/query-6ffe4dfc2048ec110ea36bbb22cb0e48971f2d2a8b25e3e82b64e4c0fae6aff7.json
+++ b/plane/.sqlx/query-6ffe4dfc2048ec110ea36bbb22cb0e48971f2d2a8b25e3e82b64e4c0fae6aff7.json
@@ -1,0 +1,59 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            select\n                node.id as \"id!\",\n                kind as \"kind!\",\n                cluster,\n                (case when\n                    controller.is_online and controller.last_heartbeat - now() < $1\n                    then controller.id\n                    else null end\n                ) as controller,\n                name as \"name!\",\n                node.plane_version as \"plane_version!\",\n                node.plane_hash as \"plane_hash!\"\n            from node\n            left join controller on controller.id = node.controller\n            where node.id = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "kind!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "cluster",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "controller",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "name!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "plane_version!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "plane_hash!",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Interval",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      null,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6ffe4dfc2048ec110ea36bbb22cb0e48971f2d2a8b25e3e82b64e4c0fae6aff7"
+}


### PR DESCRIPTION
I'm adding a function here to the PlaneDatabase that will let us pull a Node from the DB by ID. This will be used in the platform-monitor (and by other clients) to pull more information about a Node when we receive `NodeConnectionStatusChange` messages. It uses the same marshaling logic as the `list()` function.