### PR TITLE
Ignore spawns with duplicate key

### DIFF
--- a/plane/src/drone/key_manager.rs
+++ b/plane/src/drone/key_manager.rs
@@ -135,7 +135,14 @@ impl KeyManager {
         }
     }
 
-    pub fn register_key(&mut self, backend: BackendName, key: AcquiredKey) {
+    /// Register a key with the key manager, ensuring that it will be renewed.
+    /// Returns true if the key was registered, and false if it was already registered (this
+    /// should be considered an error.)
+    pub fn register_key(&mut self, backend: BackendName, key: AcquiredKey) -> bool {
+        if self.handles.contains_key(&backend) {
+            return false;
+        }
+
         let handle = GuardHandle::new(renew_key_loop(
             key.clone(),
             backend.clone(),
@@ -144,6 +151,8 @@ impl KeyManager {
         ));
 
         self.handles.insert(backend, (key, handle));
+
+        true
     }
 
     pub fn update_deadlines(&mut self, backend: &BackendName, deadlines: KeyDeadlines) {


### PR DESCRIPTION
It seems that occasionally the spawn request from the controller to the drone is received twice. We should probably add some deduping logic elsewhere, but a good sanity check when spawning is to fail with an error if the backend already exists.

This implementation piggybacks on the fact that the first thing we do with a spawn request is add the backend to the key manager. We already have a lock on the key manager when we do this, so it's cheap to additionally check if the backend ID is already in there.