### PR TITLE
Clean up containers and images

### DIFF
--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -11,12 +11,13 @@ use crate::{
 use anyhow::Result;
 use bollard::{
     auth::DockerCredentials,
-    container::StatsOptions,
+    container::{ListContainersOptions, StatsOptions},
     errors::Error,
     service::{EventMessage, HostConfigLogConfig},
     system::EventsOptions,
     Docker,
 };
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use std::sync::atomic::{AtomicU64, Ordering};
 use thiserror::Error;
 use tokio_stream::{Stream, StreamExt};
@@ -186,6 +187,82 @@ impl PlaneDocker {
             .await
             .ok_or(anyhow::anyhow!("no stats found for {container_id}"))?
             .map_err(|e| anyhow::anyhow!("{e:?}"))
+    }
+
+    /// Prune stopped backend containers that are older than the prune threshold.
+    /// Then, remove dangling images.
+    pub async fn prune(&self, since: DateTime<Utc>, auto_prune: bool) -> Result<()> {
+        tracing::info!("Pruning Docker containers and images.");
+
+        // Get a list of stopped containers with the label `dev.plane.backend`.
+        let candidates = self
+            .docker
+            .list_containers::<String>(Some(ListContainersOptions {
+                all: true,
+                filters: vec![
+                    ("label".to_string(), vec![PLANE_DOCKER_LABEL.to_string()]),
+                    ("status".to_string(), vec!["exited".to_string()]),
+                ]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            }))
+            .await?;
+
+        tracing::info!(
+            num_containers = candidates.len(),
+            "Removing stopped backend containers."
+        );
+        let mut skipped = 0;
+        for container in candidates {
+            let Some(container_created) = container.created else {
+                tracing::warn!("Received container without created timestamp.");
+                continue;
+            };
+
+            let LocalResult::Single(container_created) = Utc.timestamp_opt(container_created, 0)
+            else {
+                tracing::warn!(
+                    "Received container created timestamp that is not a valid UTC timestamp."
+                );
+                continue;
+            };
+
+            if container_created >= since {
+                tracing::info!(
+                    container_id = container.id.as_ref(),
+                    %since,
+                    %container_created,
+                    "Skipping container because it was created before the prune threshold."
+                );
+                skipped += 1;
+                continue;
+            }
+
+            let Some(container_id) = container.id else {
+                tracing::warn!("Received container without id.");
+                continue;
+            };
+            tracing::info!(container_id, "Removing container.");
+            if let Err(e) = self.docker.remove_container(&container_id, None).await {
+                tracing::error!(?e, container_id, "Error removing container.");
+            }
+        }
+
+        if skipped > 0 {
+            tracing::info!(skipped, "Skipped pruning of {} containers.", skipped);
+        }
+
+        if auto_prune {
+            match self.docker.prune_images::<&str>(None).await {
+                Ok(result) => {
+                    tracing::info!(num_images = ?result.images_deleted, "Removed dangling images.");
+                }
+                Err(e) => tracing::error!(?e, "Error pruning dangling images."),
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -8,6 +8,7 @@ use crate::{
     util::GuardHandle,
 };
 use anyhow::Result;
+use chrono::{Duration, Utc};
 use dashmap::DashMap;
 use futures_util::StreamExt;
 use std::{
@@ -15,16 +16,48 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+/// Clean up containers and images every minute.
+const CLEANUP_INTERVAL_SECS: i64 = 60;
+
 pub struct Executor {
     docker: PlaneDocker,
     state_store: Arc<Mutex<StateStore>>,
     backends: Arc<DashMap<BackendName, Arc<BackendManager>>>,
     ip: IpAddr,
     _backend_event_listener: GuardHandle,
+    _cleanup_handle: GuardHandle,
+}
+
+async fn cleanup_loop(
+    docker: PlaneDocker,
+    min_age: Duration,
+    interval: Duration,
+    auto_prune: bool,
+) {
+    loop {
+        tokio::time::sleep(
+            interval
+                .to_std()
+                .expect("Expected interval to convert to std."),
+        )
+        .await;
+
+        let since = Utc::now() - min_age;
+
+        if let Err(e) = docker.prune(since, auto_prune).await {
+            tracing::error!(?e, "Error pruning Docker containers and images.");
+        }
+    }
 }
 
 impl Executor {
-    pub fn new(docker: PlaneDocker, state_store: StateStore, ip: IpAddr) -> Self {
+    pub fn new(
+        docker: PlaneDocker,
+        state_store: StateStore,
+        ip: IpAddr,
+        auto_prune: bool,
+        cleanup_min_age: Duration,
+    ) -> Self {
         let backends: Arc<DashMap<BackendName, Arc<BackendManager>>> = Arc::default();
 
         let backend_event_listener = {
@@ -51,12 +84,26 @@ impl Executor {
             })
         };
 
+        let cleanup_handle = {
+            let docker = docker.clone();
+            GuardHandle::new(async move {
+                cleanup_loop(
+                    docker.clone(),
+                    cleanup_min_age,
+                    Duration::seconds(CLEANUP_INTERVAL_SECS),
+                    auto_prune,
+                )
+                .await;
+            })
+        };
+
         Self {
             docker,
             state_store: Arc::new(Mutex::new(state_store)),
             backends,
             ip,
             _backend_event_listener: backend_event_listener,
+            _cleanup_handle: cleanup_handle,
         }
     }
 

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use anyhow::{anyhow, Context, Result};
+use chrono::Duration;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use plane::admin::AdminOpts;
@@ -10,11 +11,12 @@ use plane::controller::run_controller;
 use plane::database::connect_and_migrate;
 use plane::dns::run_dns;
 use plane::drone::docker::PlaneDocker;
-use plane::drone::run_drone;
+use plane::drone::{run_drone, DroneConfig};
 use plane::init_tracing::init_tracing;
 use plane::names::{AcmeDnsServerName, ControllerName, DroneName, Name, OrRandom, ProxyName};
 use plane::proxy::{run_proxy, AcmeConfig, ServerPortConfig};
 use plane::types::ClusterName;
+use plane::util::resolve_hostname;
 use plane::{PLANE_GIT_HASH, PLANE_VERSION};
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -63,7 +65,7 @@ enum Command {
 
         /// IP address for this drone that proxies can connect to.
         #[clap(long, default_value = "127.0.0.1")]
-        ip: IpAddr,
+        ip: String,
 
         /// Path to the database file. If omitted, an in-memory database will be used.
         #[clap(long)]
@@ -79,6 +81,17 @@ enum Command {
         /// Optional pool identifier. If present, will only schedule workloads with a matching `pool` tag on this drone.
         #[clap(long)]
         pool: Option<String>,
+
+        /// Automatically prune stopped images.
+        /// This prunes *all* unused container images, not just ones that Plane has loaded, so it is disabled by default.
+        #[clap(long)]
+        auto_prune: bool,
+
+        /// Minimum age (in seconds) of backends to prune.
+        /// By default, all stopped backends are pruned, but you can set this to a positive number of seconds to prune
+        /// only backends that were created more than this many seconds ago.
+        #[clap(long, default_value = "0")]
+        cleanup_min_age_seconds: i32,
     },
     Proxy {
         #[clap(long)]
@@ -187,6 +200,8 @@ async fn run(opts: Opts) -> Result<()> {
             docker_runtime,
             log_config,
             pool,
+            auto_prune,
+            cleanup_min_age_seconds,
         } => {
             let name = name.or_random();
             tracing::info!(%name, "Starting drone");
@@ -198,16 +213,22 @@ async fn run(opts: Opts) -> Result<()> {
 
             let docker = PlaneDocker::new(docker, docker_runtime, log_config).await?;
 
-            run_drone(
-                client,
-                docker,
-                name,
-                cluster,
+            let ip: IpAddr = resolve_hostname(&ip)
+                .ok_or_else(|| anyhow::anyhow!("Failed to resolve hostname to IP address."))?;
+
+            let cleanup_min_age = Duration::seconds(cleanup_min_age_seconds as i64);
+
+            let drone_config = DroneConfig {
+                id: name.clone(),
+                cluster: cluster.clone(),
                 ip,
-                db.as_deref(),
-                &pool.unwrap_or_default(),
-            )
-            .await?;
+                db_path: db,
+                pool: pool.unwrap_or_default(),
+                auto_prune,
+                cleanup_min_age,
+            };
+
+            run_drone(client, docker, &drone_config).await?;
         }
         Command::Proxy {
             name,

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -85,13 +85,13 @@ enum Command {
         /// Automatically prune stopped images.
         /// This prunes *all* unused container images, not just ones that Plane has loaded, so it is disabled by default.
         #[clap(long)]
-        auto_prune: bool,
+        auto_prune_images: bool,
 
-        /// Minimum age (in seconds) of backends to prune.
+        /// Minimum age (in seconds) of backend containers to prune.
         /// By default, all stopped backends are pruned, but you can set this to a positive number of seconds to prune
         /// only backends that were created more than this many seconds ago.
         #[clap(long, default_value = "0")]
-        cleanup_min_age_seconds: i32,
+        auto_prune_containers_older_than_seconds: i32,
     },
     Proxy {
         #[clap(long)]
@@ -200,8 +200,8 @@ async fn run(opts: Opts) -> Result<()> {
             docker_runtime,
             log_config,
             pool,
-            auto_prune,
-            cleanup_min_age_seconds,
+            auto_prune_images: auto_prune,
+            auto_prune_containers_older_than_seconds: cleanup_min_age_seconds,
         } => {
             let name = name.or_random();
             tracing::info!(%name, "Starting drone");

--- a/plane/src/util.rs
+++ b/plane/src/util.rs
@@ -158,9 +158,10 @@ impl Drop for GuardHandle {
     }
 }
 
-pub fn get_internal_host_ip() -> Option<IpAddr> {
+/// Resolve a hostname to an IP address.
+pub fn resolve_hostname(hostname: &str) -> Option<IpAddr> {
     // The port is arbitrary, but needs to be provided.
-    let socket_addrs = "host.docker.internal:0".to_socket_addrs().ok()?;
+    let socket_addrs = format!("{}:0", hostname).to_socket_addrs().ok()?;
 
     for socket_addr in socket_addrs {
         if let IpAddr::V4(ip) = socket_addr.ip() {


### PR DESCRIPTION
- Add a `prune` function to `PlaneDocker` that:
  - Removes docker containers labeled as Plane backends over a certain age (based on creation time)
  - Optionally removes images that are not associated with a container
- Refactor some of the drone configuration that is passed as a growing list of arguments into a `DroneConfig` struct
- Adds cli flags `--auto-prune` and `--cleanup-min-age-seconds` to control pruning behavior.

This also removes the behavior where the drone would attempt to obtain its IP from Docker DNS. Instead, the argument to `--ip` may now be a hostname and will be attempt to be resolved, so you can pass `--ip=host.docker.internal` to achieve the old behavior.

The cleanup loop runs every minute (not currently configurable).

This will close #300.