### PR TITLE
Support docker volume mounts

### DIFF
--- a/plane/plane-tests/tests/backend_lifecycle.rs
+++ b/plane/plane-tests/tests/backend_lifecycle.rs
@@ -33,6 +33,7 @@ async fn backend_lifecycle(env: TestEnvironment) {
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
+                mount: None,
             },
             lifetime_limit_seconds: None,
             max_idle_seconds: None,

--- a/plane/plane-tests/tests/backend_status_in_response.rs
+++ b/plane/plane-tests/tests/backend_status_in_response.rs
@@ -30,6 +30,7 @@ async fn backend_status_in_response(env: TestEnvironment) {
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
+                mount: None,
             },
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -113,7 +113,7 @@ impl TestEnvironment {
         let docker = Docker::connect_with_local_defaults().unwrap();
         let db_path = self.scratch_dir.join("drone.db");
 
-        let docker = PlaneDocker::new(docker, None, None).await.unwrap();
+        let docker = PlaneDocker::new(docker, None, None, None).await.unwrap();
 
         let drone_config = DroneConfig {
             id: DroneName::new_random(),

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -107,13 +107,20 @@ impl TestEnvironment {
         controller
     }
 
-    pub async fn drone_internal(&mut self, controller: &ControllerServer, pool: &str) -> Drone {
+    pub async fn drone_internal(
+        &mut self,
+        controller: &ControllerServer,
+        pool: &str,
+        mount_base: Option<&PathBuf>,
+    ) -> Drone {
         let client = controller.client();
         let connector = client.drone_connection(&TEST_CLUSTER.parse().unwrap(), pool);
         let docker = Docker::connect_with_local_defaults().unwrap();
         let db_path = self.scratch_dir.join("drone.db");
 
-        let docker = PlaneDocker::new(docker, None, None, None).await.unwrap();
+        let docker = PlaneDocker::new(docker, None, None, mount_base.cloned())
+            .await
+            .unwrap();
 
         let drone_config = DroneConfig {
             id: DroneName::new_random(),
@@ -129,11 +136,21 @@ impl TestEnvironment {
     }
 
     pub async fn drone(&mut self, controller: &ControllerServer) -> Drone {
-        self.drone_internal(controller, &self.pool.clone()).await
+        self.drone_internal(controller, &self.pool.clone(), None)
+            .await
     }
 
     pub async fn drone_in_pool(&mut self, controller: &ControllerServer, pool: &str) -> Drone {
-        self.drone_internal(controller, pool).await
+        self.drone_internal(controller, pool, None).await
+    }
+
+    pub async fn drone_with_mount_base(
+        &mut self,
+        controller: &ControllerServer,
+        mount_base: &PathBuf,
+    ) -> Drone {
+        self.drone_internal(controller, &self.pool.clone(), Some(mount_base))
+            .await
     }
 
     pub async fn dns(&mut self, controller: &ControllerServer) -> DnsServer {

--- a/plane/plane-tests/tests/docker_command.rs
+++ b/plane/plane-tests/tests/docker_command.rs
@@ -110,6 +110,7 @@ async fn test_resource_limits() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
     config.cmd = Some(vec!["echo".into(), "hello world".into()]);

--- a/plane/plane-tests/tests/drone_pools.rs
+++ b/plane/plane-tests/tests/drone_pools.rs
@@ -32,6 +32,7 @@ async fn drone_pools(env: TestEnvironment) {
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
+                mount: None,
             },
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -15,7 +15,7 @@ mod common;
 #[plane_test]
 async fn test_get_metrics(_: TestEnvironment) {
     let docker = bollard::Docker::connect_with_local_defaults().unwrap();
-    let plane_docker = PlaneDocker::new(docker, None, None).await.unwrap();
+    let plane_docker = PlaneDocker::new(docker, None, None, None).await.unwrap();
 
     // TODO: replace with locally built hello world
     plane_docker

--- a/plane/plane-tests/tests/reuse_key.rs
+++ b/plane/plane-tests/tests/reuse_key.rs
@@ -30,6 +30,7 @@ async fn reuse_key(env: TestEnvironment) {
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
+                mount: None,
             },
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,

--- a/plane/plane-tests/tests/volume_mounts.rs
+++ b/plane/plane-tests/tests/volume_mounts.rs
@@ -1,0 +1,89 @@
+use crate::common::test_env::TestEnvironment;
+use crate::common::wait_until_backend_terminated;
+use plane::types::{
+    ConnectRequest, ExecutorConfig, KeyConfig, Mount, PullPolicy, ResourceLimits, SpawnConfig,
+};
+use plane_test_macro::plane_test;
+use serde_json::Map;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+mod common;
+
+#[plane_test]
+async fn volume_mounts(env: TestEnvironment) {
+    let mount_base = env.scratch_dir.clone();
+    let mount = "test_custom_mount";
+    let key = "test_key_mount";
+    let custom_mount_path = mount_base.join(mount);
+    let key_mount_path = mount_base.join(key);
+
+    assert!(mount_base.exists());
+    assert!(!custom_mount_path.exists());
+    assert!(!key_mount_path.exists());
+
+    let controller = env.controller().await;
+    let client = controller.client();
+    let _drone = env.drone_with_mount_base(&controller, &mount_base).await;
+
+    // Wait for the drone to register. TODO: this seems long.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    tracing::info!("Requesting backend with custom mount.");
+    let connect_request_custom_mount = ConnectRequest {
+        spawn_config: Some(SpawnConfig {
+            id: None,
+            cluster: Some(env.cluster.clone()),
+            executable: ExecutorConfig {
+                image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
+                pull_policy: Some(PullPolicy::IfNotPresent),
+                env: HashMap::default(),
+                resource_limits: ResourceLimits::default(),
+                credentials: None,
+                mount: Some(Mount::Path(PathBuf::from(mount))),
+            },
+            lifetime_limit_seconds: Some(5),
+            max_idle_seconds: None,
+            use_static_token: false,
+        }),
+        key: None,
+        user: None,
+        auth: Map::default(),
+        pool: None,
+    };
+
+    let response_custom_mount = client.connect(&connect_request_custom_mount).await.unwrap();
+    tracing::info!("Got response for custom mount.");
+    assert!(response_custom_mount.spawned);
+
+    tracing::info!("Requesting backend with key mount.");
+    let mut connect_request_key_mount = connect_request_custom_mount.clone();
+    connect_request_key_mount.key = Some(KeyConfig {
+        name: key.to_string(),
+        namespace: "".to_string(),
+        tag: "".to_string(),
+    });
+    connect_request_key_mount
+        .spawn_config
+        .as_mut()
+        .unwrap()
+        .executable
+        .mount = Some(Mount::Bool(true));
+
+    let response_key_mount = client.connect(&connect_request_key_mount).await.unwrap();
+    tracing::info!("Got response for key mount.");
+    assert!(response_key_mount.spawned);
+
+    // Wait for docker to create the folders. TODO: this seems long.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    // Ensure the mounted folders are created
+    assert!(custom_mount_path.exists());
+    assert!(key_mount_path.exists());
+
+    // Wait for the backends to terminate
+    tracing::info!("Waiting for backends to terminate.");
+    wait_until_backend_terminated(&client, &response_custom_mount.backend_id).await;
+    wait_until_backend_terminated(&client, &response_key_mount.backend_id).await;
+    tracing::info!("Backends terminated.");
+}

--- a/plane/src/drone/docker/commands.rs
+++ b/plane/src/drone/docker/commands.rs
@@ -2,7 +2,7 @@ use super::{types::ContainerId, PlaneDocker};
 use crate::{
     names::BackendName,
     protocol::AcquiredKey,
-    types::{BearerToken, ExecutorConfig},
+    types::{BearerToken, ExecutorConfig, Mount},
 };
 use anyhow::Result;
 use bollard::{
@@ -11,10 +11,16 @@ use bollard::{
     Docker,
 };
 use futures_util::StreamExt;
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
 
 /// Port inside the container to expose.
 const CONTAINER_PORT: u16 = 8080;
+/// Base directory for any data mounted in the container from the host
+const PLANE_DATA_DIR: &str = "/plane-data";
 
 pub async fn pull_image(
     docker: &Docker,
@@ -113,6 +119,44 @@ pub async fn get_port(docker: &Docker, container_id: &ContainerId) -> Result<u16
     Err(anyhow::anyhow!("Failed to get port after retries."))
 }
 
+// Canonicalize a path without talking to the filesystem.
+//
+// Copy-pasted this function from Cargo.
+// https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
+//
+// The issue is Path's canonicalize function contacts the filesystem and checks
+// if the path exists. Instead, we effectively want a string-operation.
+//
+// We use this function before passing a directory to Docker's "Binds" field,
+// which works similarly to "Mounts", but Docker also creates the directory if
+// it does not exist.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
+
 pub fn get_container_config_from_executor_config(
     backend_id: &BackendName,
     exec_config: ExecutorConfig,
@@ -120,6 +164,7 @@ pub fn get_container_config_from_executor_config(
     key: Option<&AcquiredKey>,
     static_token: Option<&BearerToken>,
     log_config: Option<&HostConfigLogConfig>,
+    mount_base: Option<&PathBuf>,
 ) -> Result<bollard::container::Config<String>> {
     let mut env = exec_config.env;
     env.insert("PORT".to_string(), CONTAINER_PORT.to_string());
@@ -145,6 +190,40 @@ pub fn get_container_config_from_executor_config(
         .into_iter()
         .map(|(k, v)| format!("{}={}", k, v))
         .collect();
+
+    let binds: Option<Vec<String>> = match (&mount_base, &exec_config.mount) {
+        (_, None) | (_, Some(Mount::Bool(false))) => None,
+        (Some(base), Some(mount_option)) => {
+            let mount_path = match mount_option {
+                Mount::Bool(true) => {
+                    if let Some(key) = key {
+                        base.join(&key.key.name)
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "Key is required for Bool(true) mount option"
+                        ));
+                    }
+                }
+                Mount::Path(path) => base.join(path),
+                _ => return Err(anyhow::anyhow!("Invalid mount option")),
+            };
+            let canonical_mount_path = normalize_path(&mount_path);
+            if !canonical_mount_path.starts_with(base) {
+                return Err(anyhow::anyhow!(
+                    "Mount path {}, which we canonicalized as {}, is not under the specified mount base {}.",
+                    mount_path.to_string_lossy(),
+                    canonical_mount_path.to_string_lossy(),
+                    base.to_string_lossy()
+                ));
+            }
+            Some(vec![format!(
+                "{}:{}",
+                canonical_mount_path.to_string_lossy(),
+                PLANE_DATA_DIR
+            )])
+        }
+        _ => None,
+    };
 
     Ok(bollard::container::Config {
         image: Some(exec_config.image.clone()),
@@ -191,6 +270,7 @@ pub fn get_container_config_from_executor_config(
                 hm.insert("size".to_string(), lim.to_string());
                 hm
             }),
+            binds,
             ..Default::default()
         }),
         ..Default::default()
@@ -204,6 +284,7 @@ pub async fn run_container(
     exec_config: ExecutorConfig,
     acquired_key: Option<&AcquiredKey>,
     static_token: Option<&BearerToken>,
+    mount_base: Option<&PathBuf>,
 ) -> Result<()> {
     let options = bollard::container::CreateContainerOptions {
         name: container_id.to_string(),
@@ -217,6 +298,7 @@ pub async fn run_container(
         acquired_key,
         static_token,
         docker.log_config.as_ref(),
+        mount_base,
     )?;
 
     docker
@@ -230,4 +312,176 @@ pub async fn run_container(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::UNIX_EPOCH;
+
+    use super::*;
+    use crate::{
+        log_types::LoggableTime,
+        names::Name,
+        protocol::{AcquiredKey, KeyDeadlines},
+        types::{ExecutorConfig, KeyConfig, Mount},
+    };
+
+    fn get_container_config_from_mount(
+        mount_base: &str,
+        mount: Option<Mount>,
+    ) -> Result<bollard::container::Config<String>> {
+        let backend_name = BackendName::new_random();
+        let key = "key";
+
+        let acquired_key = Some(AcquiredKey {
+            key: KeyConfig {
+                name: key.to_string(),
+                ..Default::default()
+            },
+            deadlines: KeyDeadlines {
+                renew_at: LoggableTime(UNIX_EPOCH.into()),
+                soft_terminate_at: LoggableTime(UNIX_EPOCH.into()),
+                hard_terminate_at: LoggableTime(UNIX_EPOCH.into()),
+            },
+            token: Default::default(),
+        });
+
+        let mut exec_config = ExecutorConfig::from_image_with_defaults(String::default());
+        exec_config.mount = mount;
+
+        get_container_config_from_executor_config(
+            &backend_name,
+            exec_config,
+            None,
+            acquired_key.as_ref(),
+            None,
+            None,
+            Some(&PathBuf::from(mount_base)),
+        )
+    }
+
+    // Test basic mount options
+
+    #[test]
+    fn test_mount_true() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Bool(true));
+        let expected_binds = Some(vec![format!("/mnt/my-nfs/key:{}", PLANE_DATA_DIR)]);
+
+        let config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+
+        assert_eq!(config, expected_binds);
+    }
+
+    #[test]
+    fn test_mount_path() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Path(PathBuf::from("custom-mount")));
+        let expected_binds = Some(vec![format!("/mnt/my-nfs/custom-mount:{}", PLANE_DATA_DIR)]);
+
+        let config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+
+        assert_eq!(config, expected_binds);
+    }
+
+    #[test]
+    fn test_mount_false() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Bool(false));
+        let expected_binds = None;
+
+        let config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+
+        assert_eq!(config, expected_binds);
+    }
+
+    #[test]
+    fn test_mount_none() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = None;
+        let expected_binds = None;
+
+        let config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+
+        assert_eq!(config, expected_binds);
+    }
+
+    // Test tricky mount paths
+
+    #[test]
+    fn test_mount_path_canonicalize() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Path(PathBuf::from(
+            "custom-mount/../different-folder/././subfolder/../../actual-folder",
+        )));
+        let expected_binds = Some(vec![format!(
+            "/mnt/my-nfs/actual-folder:{}",
+            PLANE_DATA_DIR
+        )]);
+
+        let config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+
+        assert_eq!(config, expected_binds);
+    }
+
+    // Test invalid mount paths
+
+    #[test]
+    #[should_panic(expected = "not under the specified mount base")]
+    fn test_mount_path_invalid_parent() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Path(PathBuf::from("..")));
+
+        let _config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+    }
+
+    #[test]
+    #[should_panic(expected = "not under the specified mount base")]
+    fn test_mount_path_invalid_sibling() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Path(PathBuf::from("../different-folder")));
+
+        let _config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+    }
+
+    #[test]
+    #[should_panic(expected = "not under the specified mount base")]
+    fn test_mount_path_invalid_complex_escape() {
+        let mount_base = "/mnt/my-nfs";
+        let mount = Some(Mount::Path(PathBuf::from("hide/under/../../../escape")));
+
+        let _config = get_container_config_from_mount(mount_base, mount)
+            .unwrap()
+            .host_config
+            .unwrap()
+            .binds;
+    }
 }

--- a/plane/src/drone/docker/commands.rs
+++ b/plane/src/drone/docker/commands.rs
@@ -402,41 +402,29 @@ mod tests {
     // Test invalid mount paths
 
     #[test]
-    #[should_panic(expected = "not under the mount base")]
     fn test_mount_path_invalid_parent() {
         let mount_base = "/mnt/my-nfs";
         let mount = Some(Mount::Path(PathBuf::from("..")));
 
-        let _config = get_container_config_from_mount(mount_base, mount)
-            .unwrap()
-            .host_config
-            .unwrap()
-            .binds;
+        let err = get_container_config_from_mount(mount_base, mount).unwrap_err();
+        assert!(err.to_string().contains("not under the mount base"));
     }
 
     #[test]
-    #[should_panic(expected = "not under the mount base")]
     fn test_mount_path_invalid_sibling() {
         let mount_base = "/mnt/my-nfs";
         let mount = Some(Mount::Path(PathBuf::from("../different-folder")));
 
-        let _config = get_container_config_from_mount(mount_base, mount)
-            .unwrap()
-            .host_config
-            .unwrap()
-            .binds;
+        let err = get_container_config_from_mount(mount_base, mount).unwrap_err();
+        assert!(err.to_string().contains("not under the mount base"));
     }
 
     #[test]
-    #[should_panic(expected = "not under the mount base")]
     fn test_mount_path_invalid_complex_escape() {
         let mount_base = "/mnt/my-nfs";
         let mount = Some(Mount::Path(PathBuf::from("hide/under/../../../escape")));
 
-        let _config = get_container_config_from_mount(mount_base, mount)
-            .unwrap()
-            .host_config
-            .unwrap()
-            .binds;
+        let err = get_container_config_from_mount(mount_base, mount).unwrap_err();
+        assert!(err.to_string().contains("not under the mount base"));
     }
 }

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -18,7 +18,10 @@ use bollard::{
     Docker,
 };
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+};
 use thiserror::Error;
 use tokio_stream::{Stream, StreamExt};
 
@@ -34,6 +37,7 @@ pub struct PlaneDocker {
     docker: Docker,
     runtime: Option<String>,
     log_config: Option<HostConfigLogConfig>,
+    mount_base: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -52,11 +56,13 @@ impl PlaneDocker {
         docker: Docker,
         runtime: Option<String>,
         log_config: Option<HostConfigLogConfig>,
+        mount_base: Option<PathBuf>,
     ) -> Result<Self> {
         Ok(Self {
             docker,
             runtime,
             log_config,
+            mount_base,
         })
     }
 
@@ -144,6 +150,7 @@ impl PlaneDocker {
             executable,
             acquired_key,
             static_token,
+            self.mount_base.as_ref(),
         )
         .await?;
         let port = get_port(&self.docker, container_id).await?;

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -82,6 +82,10 @@ enum Command {
         #[clap(long)]
         pool: Option<String>,
 
+        /// Optional base directory under which backends are allowed to mount directories.
+        #[clap(long)]
+        mount_base: Option<PathBuf>,
+
         /// Automatically prune stopped images.
         /// This prunes *all* unused container images, not just ones that Plane has loaded, so it is disabled by default.
         #[clap(long)]
@@ -208,6 +212,7 @@ async fn run(opts: Opts) -> Result<()> {
             docker_runtime,
             log_config,
             pool,
+            mount_base,
             auto_prune_images: auto_prune,
             auto_prune_containers_older_than_seconds: cleanup_min_age_seconds,
         } => {
@@ -219,7 +224,7 @@ async fn run(opts: Opts) -> Result<()> {
 
             let log_config = log_config.map(|s| serde_json::from_str(&s)).transpose()?;
 
-            let docker = PlaneDocker::new(docker, docker_runtime, log_config).await?;
+            let docker = PlaneDocker::new(docker, docker_runtime, log_config, mount_base).await?;
 
             let ip: IpAddr = resolve_hostname(&ip)
                 .ok_or_else(|| anyhow::anyhow!("Failed to resolve hostname to IP address."))?;

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -7,7 +7,7 @@ pub use backend_state::{BackendState, BackendStatus, TerminationKind, Terminatio
 use bollard::auth::DockerCredentials;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
 
 pub mod backend_state;
 
@@ -168,6 +168,14 @@ impl From<DockerRegistryAuth> for DockerCredentials {
     }
 }
 
+// A spawn requestor can provide a mount parameter, which can be a string or a boolean.
+#[derive(Debug, Clone, Serialize, Deserialize, valuable::Valuable)]
+#[serde(untagged)]
+pub enum Mount {
+    Bool(bool),
+    Path(PathBuf),
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, valuable::Valuable)]
 pub struct ExecutorConfig {
     pub image: String,
@@ -177,6 +185,7 @@ pub struct ExecutorConfig {
     pub env: HashMap<String, String>,
     #[serde(default)]
     pub resource_limits: ResourceLimits,
+    pub mount: Option<Mount>,
 }
 
 impl ExecutorConfig {
@@ -187,6 +196,7 @@ impl ExecutorConfig {
             env: HashMap::default(),
             resource_limits: ResourceLimits::default(),
             credentials: None,
+            mount: None,
         }
     }
 }


### PR DESCRIPTION
Fixes #586

Design doc here: https://docs.google.com/document/d/1KHkHQ823vzVDBwg5iyF6CW-pMjqNO_3LhmF1v_iNK_0/edit

Notes:
* Drone has an optional `--mount_base` command line arg. This must be an absolute path.
* Spawn requests have an optional `mount` field in the executable config. This can be a boolean or a string (details in the doc). If it's a string, it must be a _relative path_.
* The admin CLI allows you to create a connect request only an optional string `mount` (boolean is not supported).

# Test Plan 
Tested the API and CLI using the demo detailed below. 
- [x] Mounts a custom directory (screenshot is `docs` from under the plane repo)
- [x] Mounts the "key directory" when a mount is `true`, rather than a string
- [x] Creates a directory when it doesn't exist

<img width="771" alt="Screenshot 2024-02-29 at 15 20 19" src="https://github.com/drifting-in-space/plane/assets/5913522/11d376d9-bf17-4e99-b682-7b116052b12e">


Did extensive unit testing to test all possible types of `mount_base` and `mount` to ensure the correct docker mounting config is generated (in the binds field).

# Known limitations
Specifying a relative path for `mount_base` or an absolute path for `mount` will lead to a failure to mount. We do not do any validation of inputs to be friendly to the user about this.

Furthermore, a failure to mount will result in failure to spawn. The connect request will still return 200 OK but backend status will show that the backend spawn didn't succeed. There will be an error in the drone logs.

# Security
The biggest security issue to consider is escaping the `mount_base`. The unit tests should be comprehensive in showing this shouldn't be possible.

A failure to mount leads to an ERROR in the drone logs, which details the attempted mount request as follows:
```
Mount path {}, which we canonicalized as {}, is not under the specified mount base {}.
```
This will allow us to keep an eye on potentially malicious requests.

# Demo:
In this demo, we create a custom nginx image that serves any files monuted at `/plane-data`, and use this image to demo successful mounting.

`Dockerfile`:
```
FROM nginx
COPY nginx.conf /etc/nginx/nginx.conf
EXPOSE 8080
```

`nginx.conf`:
```
events {
}

http {
    server {
        listen 8080;
        server_name localhost;

        location / {
            root /plane-data;
            autoindex on;
        }
    }
}
```

Build the docker image:
```
$ docker build -t custom-nginx .
```

Then in different terminals run
```
$ ./dev/postgres.sh && ./dev/controller.sh
$ ./dev/drone.sh --mount-base '/mnt/my-nfs'
$ ./dev/proxy.sh
```

Then issue a connect request (using the newly built `custom-nginx` image):
```
$ ./dev/cli.sh connect --cluster 'localhost:9090' --mount 'some-folder' --image 'custom-nginx'
```

Finally, connect to the returned URL, and you should see nginx serving an index of `/mnt/my-nfs/some-folder`