### PR TITLE
mark-backend-lost db cli command

### DIFF
--- a/plane/src/bin/db-cli.rs
+++ b/plane/src/bin/db-cli.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::println_empty_string)]
+
 use clap::{Parser, Subcommand};
 use colored::{self, Colorize};
 use plane::{


### PR DESCRIPTION
This adds a command to the db-cli to mark backends as Lost in cases where a failure mode has left the controller believing a backend is running when it no longer is. We will ideally address these failure modes with bugfixes and reconciliation loops, but while we do that, this will be a necessary tool for making sure the controller's state is correct.