### PR TITLE
add TerminationReason::Lost

### DIFF
--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -74,6 +74,7 @@ pub enum TerminationReason {
     Swept,
     External,
     KeyExpired,
+    Lost,
 }
 
 impl BackendState {


### PR DESCRIPTION
Adding a `TerminationReason::Lost` ahead of #650 so we can bring the updated type into Jamsocket before the rest of #650 lands.