### PR TITLE
Refactor commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "plane-dynamic"
-version = "0.2.0"
+version = "0.4.7"
 dependencies = [
  "plane",
 ]
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "plane-tests"
-version = "0.2.0"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3009,6 +3009,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -33,7 +33,7 @@ rusqlite = { version = "0.30.0", features = ["bundled", "serde_json"] }
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.0"
 serde = { version = "1.0.190", features = ["derive"] }
-serde_with = "3.4.0"
+serde_with = { version = "3.4.0", features = ["chrono"] }
 serde_json = "1.0.107"
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "migrate", "json", "ipnetwork"] }
 thiserror = "1.0.50"

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -33,7 +33,7 @@ rusqlite = { version = "0.30.0", features = ["bundled", "serde_json"] }
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.0"
 serde = { version = "1.0.190", features = ["derive"] }
-serde_with = { version = "3.4.0", features = ["chrono"] }
+serde_with = "3.4.0"
 serde_json = "1.0.107"
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "migrate", "json", "ipnetwork"] }
 thiserror = "1.0.50"

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -47,6 +47,6 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "valuable"] }
 trust-dns-server = "0.23.2"
 tungstenite = "0.20.1"
-url = "2.4.1"
+url = { version="2.4.1", features=["serde"] }
 x509-parser = "0.15.1"
 valuable = { version = "0.1.0", features = ["derive"] }

--- a/plane/plane-dynamic/Cargo.toml
+++ b/plane/plane-dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-dynamic"
-version = "0.2.0"
+version = "0.4.7"
 edition = "2021"
 
 [dependencies]

--- a/plane/plane-tests/Cargo.toml
+++ b/plane/plane-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-tests"
-version = "0.2.0"
+version = "0.4.7"
 edition = "2021"
 
 [dependencies]

--- a/plane/plane-tests/tests/cert_manager.rs
+++ b/plane/plane-tests/tests/cert_manager.rs
@@ -1,4 +1,3 @@
-use crate::common::resources::pebble::Pebble;
 use crate::common::timeout::WithTimeout;
 use common::test_env::TestEnvironment;
 use plane::{
@@ -25,7 +24,7 @@ async fn cert_manager_does_refresh(env: TestEnvironment) {
     let acme_config = AcmeConfig {
         endpoint: pebble.directory_url.clone(),
         mailto_email: "test-cert@jamsocket.com".to_string(),
-        client: Pebble::client().unwrap(),
+        accept_insecure_certs_for_testing: true,
         acme_eab_keypair: None,
     };
 
@@ -71,7 +70,7 @@ async fn cert_manager_does_refresh_eab(env: TestEnvironment) {
     let acme_config = AcmeConfig {
         endpoint: pebble.directory_url.clone(),
         mailto_email: "test-cert@jamsocket.com".to_string(),
-        client: Pebble::client().unwrap(),
+        accept_insecure_certs_for_testing: true,
         acme_eab_keypair: Some(eab_keypair),
     };
 

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -8,7 +8,7 @@ use plane::{
     controller::ControllerServer,
     database::PlaneDatabase,
     dns::run_dns_with_listener,
-    drone::{docker::PlaneDocker, Drone, DroneConfig},
+    drone::{docker::PlaneDocker, Drone, DronePlan},
     names::{AcmeDnsServerName, ControllerName, DroneName, Name},
     proxy::AcmeEabConfiguration,
     types::ClusterName,
@@ -115,7 +115,7 @@ impl TestEnvironment {
 
         let docker = PlaneDocker::new(docker, None, None).await.unwrap();
 
-        let drone_config = DroneConfig {
+        let drone_config = DronePlan {
             id: DroneName::new_random(),
             cluster: TEST_CLUSTER.parse().unwrap(),
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -119,7 +119,7 @@ impl TestEnvironment {
         };
 
         let drone_config = DroneConfig {
-            id: DroneName::new_random(),
+            name: DroneName::new_random(),
             cluster: TEST_CLUSTER.parse().unwrap(),
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             db_path: Some(self.scratch_dir.join("drone.db")),

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -7,7 +7,7 @@ use plane::{
     controller::ControllerServer,
     database::PlaneDatabase,
     dns::run_dns_with_listener,
-    drone::{docker::PlaneDockerConfig, Drone, DronePlan},
+    drone::{docker::PlaneDockerConfig, Drone, DroneConfig},
     names::{AcmeDnsServerName, ControllerName, DroneName, Name},
     proxy::AcmeEabConfiguration,
     types::ClusterName,
@@ -109,7 +109,7 @@ impl TestEnvironment {
     pub async fn drone_internal(&mut self, controller: &ControllerServer, pool: &str) -> Drone {
         let db_path = self.scratch_dir.join("drone.db");
 
-        let drone_config = DronePlan {
+        let drone_config = DroneConfig {
             id: DroneName::new_random(),
             cluster: TEST_CLUSTER.parse().unwrap(),
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -2,7 +2,7 @@ use common::test_env::TestEnvironment;
 use plane::{
     drone::docker::{
         get_metrics_message_from_container_stats, types::ContainerId, MetricsConversionError,
-        PlaneDocker,
+        PlaneDocker, PlaneDockerConfig,
     },
     names::{BackendName, Name},
     types::ExecutorConfig,
@@ -15,7 +15,9 @@ mod common;
 #[plane_test]
 async fn test_get_metrics(_: TestEnvironment) {
     let docker = bollard::Docker::connect_with_local_defaults().unwrap();
-    let plane_docker = PlaneDocker::new(docker, None, None).await.unwrap();
+    let plane_docker = PlaneDocker::new(docker, PlaneDockerConfig::default())
+        .await
+        .unwrap();
 
     // TODO: replace with locally built hello world
     plane_docker

--- a/plane/src/controller/command.rs
+++ b/plane/src/controller/command.rs
@@ -1,0 +1,58 @@
+use crate::{
+    controller::run_controller,
+    database::connect_and_migrate,
+    names::{ControllerName, Name},
+    types::ClusterName,
+};
+use anyhow::Context;
+use clap::Parser;
+use std::net::IpAddr;
+use url::Url;
+
+#[derive(Parser)]
+pub struct ControllerOpts {
+    #[clap(long)]
+    db: String,
+
+    #[clap(long, default_value = "8080")]
+    port: u16,
+
+    #[clap(long, default_value = "127.0.0.1")]
+    host: IpAddr,
+
+    #[clap(long)]
+    controller_url: Option<Url>,
+
+    #[clap(long)]
+    default_cluster: Option<ClusterName>,
+
+    #[clap(long)]
+    cleanup_min_age_days: Option<i32>,
+}
+
+pub async fn controller_command(opts: ControllerOpts) -> anyhow::Result<()> {
+    let name = ControllerName::new_random();
+
+    let controller_url = match opts.controller_url {
+        Some(url) => url,
+        None => Url::parse(&format!("http://{}:{}", opts.host, opts.port))?,
+    };
+
+    tracing::info!(%name, "Starting controller. Attempting to connect to database...");
+    let db = connect_and_migrate(&opts.db)
+        .await
+        .context("Failed to connect to database and run migrations.")?;
+    tracing::info!("Connected to database.");
+
+    let addr = (opts.host, opts.port).into();
+
+    run_controller(
+        db,
+        addr,
+        name,
+        controller_url,
+        opts.default_cluster,
+        opts.cleanup_min_age_days,
+    )
+    .await
+}

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -35,6 +35,7 @@ use tracing::Level;
 use url::Url;
 
 mod backend_state;
+pub mod command;
 mod connect;
 mod core;
 mod dns;

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -265,10 +265,15 @@ impl ControllerServer {
         &self.controller_id
     }
 
-    pub fn client(&self) -> PlaneClient {
+    pub fn url(&self) -> Url {
         let base_url: Url = format!("http://{}", self.bind_addr)
             .parse()
             .expect("Generated URI is always valid.");
+        base_url
+    }
+
+    pub fn client(&self) -> PlaneClient {
+        let base_url: Url = self.url();
         PlaneClient::new(base_url)
     }
 }

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     cleanup,
     client::PlaneClient,
     controller::{connect::handle_connect, core::Controller, drone::handle_drone_socket},
-    database::PlaneDatabase,
+    database::{connect_and_migrate, PlaneDatabase},
     heartbeat_consts::HEARTBEAT_INTERVAL,
     names::ControllerName,
     signals::wait_for_shutdown_signal,
@@ -17,7 +17,7 @@ use crate::{
     util::GuardHandle,
     PLANE_GIT_HASH, PLANE_VERSION,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use axum::{
     http::{header, Method},
     routing::{get, post},
@@ -115,23 +115,20 @@ pub struct ControllerServer {
 }
 
 impl ControllerServer {
-    pub async fn run(
-        db: PlaneDatabase,
-        bind_addr: SocketAddr,
-        id: ControllerName,
-        controller_url: Url,
-        default_cluster: Option<ClusterName>,
-        cleanup_min_age_days: Option<i32>,
-    ) -> Result<Self> {
-        let listener = TcpListener::bind(bind_addr)?;
+    pub async fn run(config: ControllerConfig) -> Result<Self> {
+        let listener = TcpListener::bind(config.bind_addr)?;
+
+        let db = connect_and_migrate(&config.db_url)
+            .await
+            .context("Failed to connect to database and run migrations.")?;
 
         Self::run_with_listener(
             db,
             listener,
-            id,
-            controller_url,
-            default_cluster,
-            cleanup_min_age_days,
+            config.id,
+            config.controller_url,
+            config.default_cluster,
+            config.cleanup_min_age_days,
         )
         .await
     }
@@ -278,23 +275,18 @@ impl ControllerServer {
     }
 }
 
-pub async fn run_controller(
-    db: PlaneDatabase,
-    bind_addr: SocketAddr,
-    id: ControllerName,
-    controller_url: Url,
-    default_cluster: Option<ClusterName>,
-    cleanup_min_age_days: Option<i32>,
-) -> Result<()> {
-    let mut server = ControllerServer::run(
-        db,
-        bind_addr,
-        id,
-        controller_url,
-        default_cluster,
-        cleanup_min_age_days,
-    )
-    .await?;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControllerConfig {
+    pub db_url: String,
+    pub bind_addr: SocketAddr,
+    pub id: ControllerName,
+    pub controller_url: Url,
+    pub default_cluster: Option<ClusterName>,
+    pub cleanup_min_age_days: Option<i32>,
+}
+
+pub async fn run_controller(config: ControllerConfig) -> Result<()> {
+    let mut server = ControllerServer::run(config).await?;
 
     wait_for_shutdown_signal().await;
 

--- a/plane/src/dns/command.rs
+++ b/plane/src/dns/command.rs
@@ -1,0 +1,36 @@
+use crate::names::{AcmeDnsServerName, OrRandom};
+use clap::Parser;
+use url::Url;
+
+#[derive(Parser)]
+pub struct DnsOpts {
+    #[clap(long)]
+    name: Option<AcmeDnsServerName>,
+
+    #[clap(long)]
+    controller_url: Url,
+
+    /// Suffix to strip from requests before looking up TXT records.
+    /// E.g. if the zone is "example.com", a TXT record lookup
+    /// for foo.bar.baz.example.com
+    /// will return the TXT records for the cluster "foo.bar.baz".
+    ///
+    /// The DNS record for _acme-challenge.foo.bar.baz in this case
+    /// should have a CNAME record pointing to foo.bar.baz.example.com.
+    #[clap(long)]
+    zone: String,
+
+    #[clap(long, default_value = "53")]
+    port: u16,
+}
+
+impl DnsOpts {
+    pub fn into_config(self) -> crate::dns::DnsConfig {
+        crate::dns::DnsConfig {
+            name: self.name.or_random(),
+            controller_url: self.controller_url,
+            port: self.port,
+            zone: Some(self.zone),
+        }
+    }
+}

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -1,0 +1,85 @@
+use crate::{
+    client::PlaneClient,
+    drone::{docker::PlaneDocker, run_drone, DroneConfig},
+    names::{DroneName, OrRandom},
+    types::ClusterName,
+    util::resolve_hostname,
+};
+use chrono::Duration;
+use clap::Parser;
+use std::{net::IpAddr, path::PathBuf};
+use url::Url;
+
+#[derive(Parser)]
+pub struct DroneOpts {
+    #[clap(long)]
+    name: Option<DroneName>,
+
+    #[clap(long)]
+    controller_url: Url,
+
+    #[clap(long)]
+    cluster: ClusterName,
+
+    /// IP address for this drone that proxies can connect to.
+    #[clap(long, default_value = "127.0.0.1")]
+    ip: String,
+
+    /// Path to the database file. If omitted, an in-memory database will be used.
+    #[clap(long)]
+    db: Option<PathBuf>,
+
+    #[clap(long)]
+    docker_runtime: Option<String>,
+
+    /// Optional log driver configuration, passed to Docker as the `LogConfig` field.
+    #[clap(long)]
+    log_config: Option<String>,
+
+    /// Optional pool identifier. If present, will only schedule workloads with a matching `pool` tag on this drone.
+    #[clap(long)]
+    pool: Option<String>,
+
+    /// Automatically prune stopped images.
+    /// This prunes *all* unused container images, not just ones that Plane has loaded, so it is disabled by default.
+    #[clap(long)]
+    auto_prune_images: bool,
+
+    /// Minimum age (in seconds) of backend containers to prune.
+    /// By default, all stopped backends are pruned, but you can set this to a positive number of seconds to prune
+    /// only backends that were created more than this many seconds ago.
+    #[clap(long, default_value = "0")]
+    auto_prune_containers_older_than_seconds: i32,
+}
+
+pub async fn drone_command(opts: DroneOpts) -> anyhow::Result<()> {
+    let name = opts.name.or_random();
+    tracing::info!(%name, "Starting drone");
+
+    let client = PlaneClient::new(opts.controller_url);
+    let docker = bollard::Docker::connect_with_local_defaults()?;
+
+    let log_config = opts
+        .log_config
+        .map(|s| serde_json::from_str(&s))
+        .transpose()?;
+
+    let docker = PlaneDocker::new(docker, opts.docker_runtime, log_config).await?;
+
+    let ip: IpAddr = resolve_hostname(&opts.ip)
+        .ok_or_else(|| anyhow::anyhow!("Failed to resolve hostname to IP address."))?;
+
+    let cleanup_min_age = Duration::seconds(opts.auto_prune_containers_older_than_seconds as i64);
+
+    let drone_config = DroneConfig {
+        id: name.clone(),
+        cluster: opts.cluster.clone(),
+        ip,
+        db_path: opts.db,
+        pool: opts.pool.unwrap_or_default(),
+        auto_prune: opts.auto_prune_images,
+        cleanup_min_age,
+    };
+
+    run_drone(client, docker, &drone_config).await
+}

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -59,7 +59,6 @@ pub struct DroneOpts {
 impl DroneOpts {
     pub fn into_config(self) -> Result<DroneConfig> {
         let name = self.name.or_random();
-        tracing::info!(%name, "Starting drone");
 
         let log_config = self
             .log_config
@@ -81,7 +80,7 @@ impl DroneOpts {
 
         let drone_config = DroneConfig {
             controller_url: self.controller_url,
-            id: name.clone(),
+            name: name.clone(),
             cluster: self.cluster.clone(),
             ip,
             db_path: self.db,

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    drone::{docker::PlaneDockerConfig, DronePlan},
+    drone::{docker::PlaneDockerConfig, DroneConfig},
     names::{DroneName, OrRandom},
     types::ClusterName,
     util::resolve_hostname,
@@ -53,7 +53,7 @@ pub struct DroneOpts {
 }
 
 impl DroneOpts {
-    pub fn into_plan(self) -> Result<DronePlan> {
+    pub fn into_config(self) -> Result<DroneConfig> {
         let name = self.name.or_random();
         tracing::info!(%name, "Starting drone");
 
@@ -73,7 +73,7 @@ impl DroneOpts {
         let cleanup_min_age =
             Duration::seconds(self.auto_prune_containers_older_than_seconds as i64);
 
-        let drone_plan = DronePlan {
+        let drone_config = DroneConfig {
             controller_url: self.controller_url,
             id: name.clone(),
             cluster: self.cluster.clone(),
@@ -85,6 +85,6 @@ impl DroneOpts {
             docker_config,
         };
 
-        Ok(drone_plan)
+        Ok(drone_config)
     }
 }

--- a/plane/src/drone/docker/commands.rs
+++ b/plane/src/drone/docker/commands.rs
@@ -213,10 +213,10 @@ pub async fn run_container(
     let config = get_container_config_from_executor_config(
         backend_id,
         exec_config,
-        docker.runtime.as_deref(),
+        docker.config.runtime.as_deref(),
         acquired_key,
         static_token,
-        docker.log_config.as_ref(),
+        docker.config.log_config.as_ref(),
     )?;
 
     docker

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -29,7 +29,7 @@ pub mod types;
 /// The existence of this label is used to determine whether a container is managed by Plane.
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PlaneDockerConfig {
     pub runtime: Option<String>,
     pub log_config: Option<HostConfigLogConfig>,

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -18,6 +18,7 @@ use bollard::{
     Docker,
 };
 use chrono::{DateTime, LocalResult, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use thiserror::Error;
 use tokio_stream::{Stream, StreamExt};
@@ -29,7 +30,7 @@ pub mod types;
 /// The existence of this label is used to determine whether a container is managed by Plane.
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct PlaneDockerConfig {
     pub runtime: Option<String>,
     pub log_config: Option<HostConfigLogConfig>,

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -30,10 +30,15 @@ pub mod types;
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
 #[derive(Clone, Debug)]
+pub struct PlaneDockerConfig {
+    pub runtime: Option<String>,
+    pub log_config: Option<HostConfigLogConfig>,
+}
+
+#[derive(Clone, Debug)]
 pub struct PlaneDocker {
     docker: Docker,
-    runtime: Option<String>,
-    log_config: Option<HostConfigLogConfig>,
+    config: PlaneDockerConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -48,16 +53,8 @@ pub struct SpawnResult {
 }
 
 impl PlaneDocker {
-    pub async fn new(
-        docker: Docker,
-        runtime: Option<String>,
-        log_config: Option<HostConfigLogConfig>,
-    ) -> Result<Self> {
-        Ok(Self {
-            docker,
-            runtime,
-            log_config,
-        })
+    pub async fn new(docker: Docker, config: PlaneDockerConfig) -> Result<Self> {
+        Ok(Self { docker, config })
     }
 
     pub async fn pull(

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -185,7 +185,7 @@ impl Drone {
             config.cleanup_min_age,
         );
 
-        let id = config.id.clone();
+        let id = config.name.clone();
         let drone_loop = tokio::spawn(drone_loop(id.clone(), connector, executor));
 
         Ok(Self { drone_loop, id })
@@ -198,7 +198,7 @@ impl Drone {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DroneConfig {
-    pub id: DroneName,
+    pub name: DroneName,
     pub docker_config: PlaneDockerConfig,
     pub controller_url: Url,
     pub cluster: ClusterName,
@@ -211,6 +211,7 @@ pub struct DroneConfig {
 }
 
 pub async fn run_drone(config: DroneConfig) -> Result<()> {
+    tracing::info!(name=%config.name, "Starting drone");
     let drone = Drone::run(config).await?;
 
     tracing::info!("Drone started.");

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -158,7 +158,7 @@ pub struct Drone {
 }
 
 impl Drone {
-    pub async fn run(config: DronePlan) -> Result<Self> {
+    pub async fn run(config: DroneConfig) -> Result<Self> {
         let client = PlaneClient::new(config.controller_url);
         let docker =
             PlaneDocker::new(Docker::connect_with_local_defaults()?, config.docker_config).await?;
@@ -197,7 +197,7 @@ impl Drone {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DronePlan {
+pub struct DroneConfig {
     pub id: DroneName,
     pub docker_config: PlaneDockerConfig,
     pub controller_url: Url,
@@ -210,8 +210,8 @@ pub struct DronePlan {
     pub cleanup_min_age: Duration,
 }
 
-pub async fn run_drone(plan: DronePlan) -> Result<()> {
-    let drone = Drone::run(plan).await?;
+pub async fn run_drone(config: DroneConfig) -> Result<()> {
+    let drone = Drone::run(config).await?;
 
     tracing::info!("Drone started.");
     wait_for_shutdown_signal().await;

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use bollard::Docker;
 use chrono::Duration;
 use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
 use std::{
     fs::{set_permissions, File, Permissions},
     net::IpAddr,
@@ -195,6 +196,7 @@ impl Drone {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DronePlan {
     pub id: DroneName,
     pub docker_config: PlaneDockerConfig,
@@ -204,6 +206,7 @@ pub struct DronePlan {
     pub db_path: Option<PathBuf>,
     pub pool: String,
     pub auto_prune: bool,
+    #[serde(with = "crate::serialization::serialize_duration_as_seconds")]
     pub cleanup_min_age: Duration,
 }
 

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -25,6 +25,7 @@ use tokio::task::JoinHandle;
 use valuable::Valuable;
 
 mod backend_manager;
+pub mod command;
 pub mod docker;
 mod executor;
 mod heartbeat;

--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -17,6 +17,7 @@ pub mod log_types;
 pub mod names;
 pub mod protocol;
 pub mod proxy;
+pub mod serialization;
 pub mod signals;
 pub mod typed_socket;
 pub mod types;

--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -2,6 +2,10 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![doc = include_str!("../README.md")]
 
+use controller::ControllerConfig;
+use dns::DnsConfig;
+use drone::DroneConfig;
+use proxy::ProxyConfig;
 use serde::{Deserialize, Serialize};
 
 pub mod admin;
@@ -40,4 +44,12 @@ pub fn plane_version_info() -> PlaneVersionInfo {
         version: PLANE_VERSION.to_string(),
         git_hash: PLANE_GIT_HASH.to_string(),
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Plan {
+    Controller(ControllerConfig),
+    Dns(DnsConfig),
+    Proxy(ProxyConfig),
+    Drone(DroneConfig),
 }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -12,7 +12,8 @@ use plane::dns::run_dns;
 use plane::drone::command::{drone_command, DroneOpts};
 use plane::init_tracing::init_tracing;
 use plane::names::{AcmeDnsServerName, OrRandom};
-use plane::proxy::command::{proxy_command, ProxyOpts};
+use plane::proxy::command::ProxyOpts;
+use plane::proxy::run_proxy;
 use plane::{PLANE_GIT_HASH, PLANE_VERSION};
 use url::Url;
 
@@ -59,7 +60,7 @@ async fn run(opts: Opts) -> Result<()> {
     match opts.command {
         Command::Controller(opts) => controller_command(opts).await?,
         Command::Drone(opts) => drone_command(opts).await?,
-        Command::Proxy(opts) => proxy_command(opts).await?,
+        Command::Proxy(opts) => run_proxy(opts.into_plan()?).await?,
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;
         }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -5,19 +5,17 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use plane::admin::AdminOpts;
-use plane::client::PlaneClient;
 use plane::controller::command::ControllerOpts;
 use plane::controller::run_controller;
 use plane::database::connect_and_migrate;
+use plane::dns::command::DnsOpts;
 use plane::dns::run_dns;
 use plane::drone::command::DroneOpts;
 use plane::drone::run_drone;
 use plane::init_tracing::init_tracing;
-use plane::names::{AcmeDnsServerName, OrRandom};
 use plane::proxy::command::ProxyOpts;
 use plane::proxy::run_proxy;
 use plane::{PLANE_GIT_HASH, PLANE_VERSION};
-use url::Url;
 
 #[derive(Parser)]
 struct Opts {
@@ -30,26 +28,7 @@ enum Command {
     Controller(ControllerOpts),
     Drone(DroneOpts),
     Proxy(ProxyOpts),
-    Dns {
-        #[clap(long)]
-        name: Option<AcmeDnsServerName>,
-
-        #[clap(long)]
-        controller_url: Url,
-
-        /// Suffix to strip from requests before looking up TXT records.
-        /// E.g. if the zone is "example.com", a TXT record lookup
-        /// for foo.bar.baz.example.com
-        /// will return the TXT records for the cluster "foo.bar.baz".
-        ///
-        /// The DNS record for _acme-challenge.foo.bar.baz in this case
-        /// should have a CNAME record pointing to foo.bar.baz.example.com.
-        #[clap(long)]
-        zone: String,
-
-        #[clap(long, default_value = "53")]
-        port: u16,
-    },
+    Dns(DnsOpts),
     Migrate {
         #[clap(long)]
         db: String,
@@ -66,17 +45,7 @@ async fn run(opts: Opts) -> Result<()> {
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;
         }
-        Command::Dns {
-            name,
-            controller_url,
-            port,
-            zone,
-        } => {
-            let name = name.or_random();
-            tracing::info!("Starting DNS server");
-            let client = PlaneClient::new(controller_url);
-            run_dns(name, client, port, Some(zone)).await?;
-        }
+        Command::Dns(opts) => run_dns(opts.into_config()).await?,
         Command::Admin(admin_opts) => {
             plane::admin::run_admin_command(admin_opts).await;
         }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -60,8 +60,8 @@ enum Command {
 async fn run(opts: Opts) -> Result<()> {
     match opts.command {
         Command::Controller(opts) => controller_command(opts).await?,
-        Command::Drone(opts) => run_drone(opts.into_plan()?).await?,
-        Command::Proxy(opts) => run_proxy(opts.into_plan()?).await?,
+        Command::Drone(opts) => run_drone(opts.into_config()?).await?,
+        Command::Proxy(opts) => run_proxy(opts.into_config()?).await?,
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;
         }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -6,7 +6,8 @@ use clap::{Parser, Subcommand};
 use colored::Colorize;
 use plane::admin::AdminOpts;
 use plane::client::PlaneClient;
-use plane::controller::command::{controller_command, ControllerOpts};
+use plane::controller::command::ControllerOpts;
+use plane::controller::run_controller;
 use plane::database::connect_and_migrate;
 use plane::dns::run_dns;
 use plane::drone::command::DroneOpts;
@@ -59,7 +60,7 @@ enum Command {
 
 async fn run(opts: Opts) -> Result<()> {
     match opts.command {
-        Command::Controller(opts) => controller_command(opts).await?,
+        Command::Controller(opts) => run_controller(opts.into_config()?).await?,
         Command::Drone(opts) => run_drone(opts.into_config()?).await?,
         Command::Proxy(opts) => run_proxy(opts.into_config()?).await?,
         Command::Migrate { db } => {

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -47,10 +47,10 @@ async fn run(opts: Opts) -> Result<()> {
         Command::Controller(opts) => run_controller(opts.into_config()?).await?,
         Command::Drone(opts) => run_drone(opts.into_config()?).await?,
         Command::Proxy(opts) => run_proxy(opts.into_config()?).await?,
+        Command::Dns(opts) => run_dns(opts.into_config()).await?,
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;
         }
-        Command::Dns(opts) => run_dns(opts.into_config()).await?,
         Command::Admin(admin_opts) => {
             plane::admin::run_admin_command(admin_opts).await;
         }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -9,7 +9,8 @@ use plane::client::PlaneClient;
 use plane::controller::command::{controller_command, ControllerOpts};
 use plane::database::connect_and_migrate;
 use plane::dns::run_dns;
-use plane::drone::command::{drone_command, DroneOpts};
+use plane::drone::command::DroneOpts;
+use plane::drone::run_drone;
 use plane::init_tracing::init_tracing;
 use plane::names::{AcmeDnsServerName, OrRandom};
 use plane::proxy::command::ProxyOpts;
@@ -59,7 +60,7 @@ enum Command {
 async fn run(opts: Opts) -> Result<()> {
     match opts.command {
         Command::Controller(opts) => controller_command(opts).await?,
-        Command::Drone(opts) => drone_command(opts).await?,
+        Command::Drone(opts) => run_drone(opts.into_plan()?).await?,
         Command::Proxy(opts) => run_proxy(opts.into_plan()?).await?,
         Command::Migrate { db } => {
             let _ = connect_and_migrate(&db).await?;

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -31,7 +31,7 @@ enum Command {
     Proxy(ProxyOpts),
     Dns(DnsOpts),
     /// Run a Plane instance from a JSON configuration file.
-    Plan {
+    RunConfig {
         config_file: PathBuf,
     },
     Migrate {
@@ -58,7 +58,7 @@ async fn run(opts: Opts) -> Result<()> {
             println!("Client version: {}", PLANE_VERSION.bright_white());
             println!("Client hash: {}", PLANE_GIT_HASH.bright_white());
         }
-        Command::Plan { config_file } => {
+        Command::RunConfig { config_file } => {
             if !config_file.ends_with(".json") {
                 // This check is so that we can potentially support other formats in the future
                 // without breaking backwards compatibility.

--- a/plane/src/proxy/cert_manager.rs
+++ b/plane/src/proxy/cert_manager.rs
@@ -324,8 +324,10 @@ async fn get_certificate(
     request_sender: &(impl Fn(CertManagerRequest) + Send + Sync + 'static),
     response_receiver: &mut broadcast::Receiver<CertManagerResponse>,
 ) -> anyhow::Result<CertificatePair> {
+    let client = reqwest::Client::new();
+
     let dir = DirectoryBuilder::new(acme_config.endpoint.to_string())
-        .http_client(acme_config.client.clone())
+        .http_client(client)
         .build()
         .await
         .context("Building directory")?;

--- a/plane/src/proxy/command.rs
+++ b/plane/src/proxy/command.rs
@@ -108,7 +108,6 @@ impl ProxyOpts {
                 endpoint,
                 mailto_email: email,
                 acme_eab_keypair,
-                client: reqwest::Client::new(),
             }),
             (None, None) => None,
         };

--- a/plane/src/proxy/command.rs
+++ b/plane/src/proxy/command.rs
@@ -1,0 +1,126 @@
+use crate::{
+    client::PlaneClient,
+    names::{OrRandom, ProxyName},
+    proxy::{run_proxy, AcmeConfig, AcmeEabConfiguration, ServerPortConfig},
+    types::ClusterName,
+};
+use anyhow::anyhow;
+use clap::Parser;
+use std::path::PathBuf;
+use url::Url;
+
+const LOCAL_HTTP_PORT: u16 = 9090;
+const PROD_HTTP_PORT: u16 = 80;
+const PROD_HTTPS_PORT: u16 = 443;
+
+#[derive(Parser)]
+pub struct ProxyOpts {
+    #[clap(long)]
+    name: Option<ProxyName>,
+
+    #[clap(long)]
+    controller_url: Url,
+
+    #[clap(long)]
+    cluster: ClusterName,
+
+    #[clap(long)]
+    https: bool,
+
+    #[clap(long)]
+    http_port: Option<u16>,
+
+    #[clap(long)]
+    https_port: Option<u16>,
+
+    #[clap(long)]
+    cert_path: Option<PathBuf>,
+
+    #[clap(long)]
+    acme_endpoint: Option<Url>,
+
+    #[clap(long)]
+    acme_email: Option<String>,
+
+    /// Key identifier when using ACME External Account Binding.
+    #[clap(long)]
+    acme_eab_kid: Option<String>,
+
+    /// HMAC key when using ACME External Account Binding.
+    #[clap(long)]
+    acme_eab_hmac_key: Option<String>,
+
+    /// URL to redirect the root path to.
+    #[clap(long)]
+    root_redirect_url: Option<Url>,
+}
+
+pub async fn proxy_command(opts: ProxyOpts) -> anyhow::Result<()> {
+    let name = opts.name.or_random();
+    tracing::info!(?name, "Starting proxy");
+    let client = PlaneClient::new(opts.controller_url);
+
+    let port_config = match (opts.https, opts.http_port, opts.https_port) {
+        (false, None, None) => ServerPortConfig {
+            http_port: LOCAL_HTTP_PORT,
+            https_port: None,
+        },
+        (true, None, None) => ServerPortConfig {
+            http_port: PROD_HTTP_PORT,
+            https_port: Some(PROD_HTTPS_PORT),
+        },
+        (true, Some(http_port), None) => ServerPortConfig {
+            http_port,
+            https_port: Some(PROD_HTTPS_PORT),
+        },
+        (_, None, Some(https_port)) => ServerPortConfig {
+            http_port: PROD_HTTP_PORT,
+            https_port: Some(https_port),
+        },
+        (_, Some(http_port), https_port) => ServerPortConfig {
+            http_port,
+            https_port,
+        },
+    };
+
+    let acme_eab_keypair = match (opts.acme_eab_hmac_key, opts.acme_eab_kid) {
+        (Some(hmac_key), Some(kid)) => Some(AcmeEabConfiguration::new(&kid, &hmac_key)?),
+        (None, Some(_)) | (Some(_), None) => {
+            return Err(anyhow!(
+                "Must specify both --acme-eab-hmac-key and --acme-eab-kid or neither."
+            ))
+        }
+        _ => None,
+    };
+
+    let acme_config = match (opts.acme_endpoint, opts.acme_email) {
+        (Some(_), None) => {
+            return Err(anyhow!(
+                "Must specify --acme-email when using --acme-endpoint."
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(anyhow!(
+                "Must specify --acme-endpoint when using --acme-email."
+            ));
+        }
+        (Some(endpoint), Some(email)) => Some(AcmeConfig {
+            endpoint,
+            mailto_email: email,
+            acme_eab_keypair,
+            client: reqwest::Client::new(),
+        }),
+        (None, None) => None,
+    };
+
+    run_proxy(
+        name,
+        client,
+        opts.cluster,
+        opts.cert_path.as_deref(),
+        port_config,
+        acme_config,
+        opts.root_redirect_url,
+    )
+    .await
+}

--- a/plane/src/proxy/command.rs
+++ b/plane/src/proxy/command.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use std::path::PathBuf;
 use url::Url;
 
-use super::ProxyPlan;
+use super::ProxyConfig;
 
 const LOCAL_HTTP_PORT: u16 = 9090;
 const PROD_HTTP_PORT: u16 = 80;
@@ -57,7 +57,7 @@ pub struct ProxyOpts {
 }
 
 impl ProxyOpts {
-    pub fn into_plan(self) -> Result<ProxyPlan> {
+    pub fn into_config(self) -> Result<ProxyConfig> {
         let name = self.name.or_random();
 
         let port_config = match (self.https, self.http_port, self.https_port) {
@@ -113,7 +113,7 @@ impl ProxyOpts {
             (None, None) => None,
         };
 
-        Ok(ProxyPlan {
+        Ok(ProxyConfig {
             name,
             controller_url: self.controller_url,
             cluster: self.cluster,

--- a/plane/src/proxy/command.rs
+++ b/plane/src/proxy/command.rs
@@ -108,6 +108,7 @@ impl ProxyOpts {
                 endpoint,
                 mailto_email: email,
                 acme_eab_keypair,
+                accept_insecure_certs_for_testing: false,
             }),
             (None, None) => None,
         };

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -80,6 +80,14 @@ pub struct AcmeConfig {
     pub endpoint: Url,
     pub mailto_email: String,
     pub acme_eab_keypair: Option<AcmeEabConfiguration>,
+    /// Don't validate the ACME server's certificate chain. This is ONLY for testing,
+    /// and should not be used otherwise.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub accept_insecure_certs_for_testing: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -5,6 +5,7 @@ use crate::proxy::proxy_service::ProxyMakeService;
 use crate::proxy::shutdown_signal::ShutdownSignal;
 use crate::{client::PlaneClient, signals::wait_for_shutdown_signal, types::ClusterName};
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::path::PathBuf;
 use url::Url;
@@ -48,7 +49,7 @@ pub struct ForwardableRequestInfo {
     protocol: Protocol,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct ServerPortConfig {
     pub http_port: u16,
     pub https_port: Option<u16>,
@@ -74,7 +75,7 @@ impl AcmeEabConfiguration {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcmeConfig {
     pub endpoint: Url,
     pub mailto_email: String,
@@ -82,6 +83,7 @@ pub struct AcmeConfig {
     pub acme_eab_keypair: Option<AcmeEabConfiguration>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyPlan {
     pub name: ProxyName,
     pub controller_url: Url,

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -102,6 +102,7 @@ pub struct ProxyConfig {
 }
 
 pub async fn run_proxy(config: ProxyConfig) -> Result<()> {
+    tracing::info!(name=%config.name, "Starting proxy");
     let client = PlaneClient::new(config.controller_url);
     let (mut cert_watcher, cert_manager) = watcher_manager_pair(
         config.cluster.clone(),

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -55,7 +55,7 @@ pub struct ServerPortConfig {
     pub https_port: Option<u16>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcmeEabConfiguration {
     pub key_id: String,
     pub key: Vec<u8>,
@@ -79,7 +79,6 @@ impl AcmeEabConfiguration {
 pub struct AcmeConfig {
     pub endpoint: Url,
     pub mailto_email: String,
-    pub client: reqwest::Client,
     pub acme_eab_keypair: Option<AcmeEabConfiguration>,
 }
 

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -11,6 +11,7 @@ use url::Url;
 
 pub mod cert_manager;
 mod cert_pair;
+pub mod command;
 mod connection_monitor;
 pub mod proxy_connection;
 mod proxy_service;

--- a/plane/src/serialization.rs
+++ b/plane/src/serialization.rs
@@ -6,7 +6,7 @@ pub mod serialize_duration_as_seconds {
     where
         S: Serializer,
     {
-        serializer.serialize_i64(duration.num_seconds() as i64)
+        serializer.serialize_i64(duration.num_seconds())
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>

--- a/plane/src/serialization.rs
+++ b/plane/src/serialization.rs
@@ -1,0 +1,19 @@
+pub mod serialize_duration_as_seconds {
+    use chrono::Duration;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_i64(duration.num_seconds() as i64)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let seconds: i64 = Deserialize::deserialize(deserializer)?;
+        Ok(Duration::seconds(seconds))
+    }
+}


### PR DESCRIPTION
Currently, the pipeline from CLI options to a running Plane drone/proxy/controller/DNS server is a bit ad-hoc and different for each component. This PR standardizes all four into a common pattern:

- The CLI options definition (clap parser) is moved out of `main.rs` and into `[component]/command.rs`. The options structs are given a name ending in `Opts`, e.g. `ProxyOpts`.
- For each component type, an additional `*Config` struct is defined, like `ProxyConfig`.
- Each `*Opts` struct gets an `.into_config()` method which converts it into the corresponding `*Config` type.

The resulting `main` command looks like this:

```rust
async fn run(opts: Opts) -> Result<()> {
    match opts.command {
        Command::Controller(opts) => run_controller(opts.into_config()?).await?,
        Command::Drone(opts) => run_drone(opts.into_config()?).await?,
        Command::Proxy(opts) => run_proxy(opts.into_config()?).await?,
        Command::Dns(opts) => run_dns(opts.into_config()).await?,
```

The real driver for this is that as we add more config options, maintaining CLI options gets hairy. This PR also introduces a `Plan` enum which can represent configs for any of the component types. It also introduces a `run-config` command for running a `Plan` that has been serialized to a JSON file on disk. This can be used as a way to specify a configuration in a type-safe way.