### PR TITLE
fix quickstart image on mac

### DIFF
--- a/docker/quickstart/README.md
+++ b/docker/quickstart/README.md
@@ -15,6 +15,7 @@ docker run \
     -p 8080:8080 \
     -p 9090:9090 \
     -v /var/run/docker.sock:/var/run/docker.sock \
+    --add-host=host.docker.internal:host-gateway \
     plane/quickstart
 ```
 

--- a/docker/quickstart/supervisord.conf
+++ b/docker/quickstart/supervisord.conf
@@ -21,7 +21,7 @@ stderr_logfile=/var/log/plane-controller-stderr.log
 stdout_logfile=/var/log/plane-controller-stdout.log
 
 [program:plane-drone]
-command=/bin/plane drone --controller-url ws://localhost:8080 --ip 172.17.0.1 --cluster 'localhost:9090'
+command=/bin/plane drone --controller-url ws://localhost:8080 --ip 'host.docker.internal' --cluster 'localhost:9090'
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/plane-drone-stderr.log


### PR DESCRIPTION
This fixes the Quickstart image on a mac, but breaks it on Linux.

[This PR](https://github.com/drifting-in-space/plane/pull/607) fixed that by relying on the admittedly awkward behavior of the previous `--ip` flag which [was only used](https://github.com/drifting-in-space/plane/pull/642/files#diff-a2f5b466f90757cf3ddcd106024fc1492f9ad5966124478fcb335c6364fb9a5cL200-L206) if `host.docker.internal` didn't resolve to anything.

@paulgb Any ideas on a good way to get this passing in the right IP/host for both Mac and Linux?