### PR TITLE
Deserialize key as base64

### DIFF
--- a/plane/plane-tests/tests/cert_manager.rs
+++ b/plane/plane-tests/tests/cert_manager.rs
@@ -59,8 +59,8 @@ async fn cert_manager_does_refresh_eab(env: TestEnvironment) {
     let dns = env.dns(&controller).await;
 
     let eab_keypair = AcmeEabConfiguration::new(
-        "kid-1",
-        "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+        "kid-1".to_string(),
+        "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W".to_string(),
     )
     .unwrap();
 

--- a/plane/src/proxy/cert_manager.rs
+++ b/plane/src/proxy/cert_manager.rs
@@ -343,7 +343,7 @@ async fn get_certificate(
     // builder.private_key(...);
     builder.contact(vec![format!("mailto:{}", acme_config.mailto_email)]);
     if let Some(acme_eab_keypair) = acme_config.acme_eab_keypair.clone() {
-        let eab_key = openssl::pkey::PKey::hmac(&acme_eab_keypair.key)?;
+        let eab_key = openssl::pkey::PKey::hmac(&acme_eab_keypair.key_bytes()?)?;
         builder.external_account_binding(acme_eab_keypair.key_id.clone(), eab_key);
     }
     builder.terms_of_service_agreed(true);

--- a/plane/src/proxy/command.rs
+++ b/plane/src/proxy/command.rs
@@ -84,7 +84,7 @@ impl ProxyOpts {
         };
 
         let acme_eab_keypair = match (self.acme_eab_hmac_key, self.acme_eab_kid) {
-            (Some(hmac_key), Some(kid)) => Some(AcmeEabConfiguration::new(&kid, &hmac_key)?),
+            (Some(hmac_key), Some(kid)) => Some(AcmeEabConfiguration::new(kid, hmac_key)?),
             (None, Some(_)) | (Some(_), None) => {
                 return Err(anyhow!(
                     "Must specify both --acme-eab-hmac-key and --acme-eab-kid or neither."

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -66,7 +66,6 @@ pub struct AcmeEabConfiguration {
 
 impl AcmeEabConfiguration {
     pub fn eab_key_b64(&self) -> String {
-        // data_encoding::BASE64URL_NOPAD.encode(&self.key)
         self.key.clone()
     }
 

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -57,21 +57,29 @@ pub struct ServerPortConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcmeEabConfiguration {
+    /// The key identifier for the ACME EAB key.
     pub key_id: String,
-    pub key: Vec<u8>,
+
+    /// The HMAC key for the ACME EAB key, base64-encoded (URL, no-pad).
+    pub key: String,
 }
 
 impl AcmeEabConfiguration {
     pub fn eab_key_b64(&self) -> String {
-        data_encoding::BASE64URL_NOPAD.encode(&self.key)
+        // data_encoding::BASE64URL_NOPAD.encode(&self.key)
+        self.key.clone()
     }
 
-    pub fn new(key_id: &str, key_b64: &str) -> Result<Self> {
-        let key = data_encoding::BASE64URL_NOPAD.decode(key_b64.as_bytes())?;
+    pub fn new(key_id: String, key_b64: String) -> Result<Self> {
+        let _ = data_encoding::BASE64URL_NOPAD.decode(key_b64.as_bytes())?;
         Ok(Self {
-            key_id: key_id.into(),
-            key,
+            key_id,
+            key: key_b64,
         })
+    }
+
+    pub fn key_bytes(&self) -> Result<Vec<u8>> {
+        Ok(data_encoding::BASE64URL_NOPAD.decode(self.key.as_bytes())?)
     }
 }
 


### PR DESCRIPTION
`AcmeEabConfiguration` is part of the config schema now, but it stores the EAB key internally as a `Vec<u8>` rather than as a base64-encoded string. This makes for an ugly serialized representation. This changes the internal type to be a base64-encoded string, and parses it into bytes with a method.