### PR TITLE
Handle missed backend actions

### DIFF
--- a/plane/src/controller/drone.rs
+++ b/plane/src/controller/drone.rs
@@ -149,11 +149,7 @@ pub async fn process_pending_actions(
     drone_id: &NodeId,
 ) -> Result<(), anyhow::Error> {
     let mut count = 0;
-    for pending_action in db
-        .backend_actions()
-        .pending_actions(*drone_id)
-        .await?
-    {
+    for pending_action in db.backend_actions().pending_actions(*drone_id).await? {
         let message = MessageToDrone::Action(pending_action);
         socket.send(message).await?;
         count += 1;

--- a/plane/src/controller/drone.rs
+++ b/plane/src/controller/drone.rs
@@ -151,7 +151,7 @@ pub async fn process_pending_actions(
     let mut count = 0;
     for pending_action in db
         .backend_actions()
-        .pending_actions(drone_id.clone())
+        .pending_actions(*drone_id)
         .await?
     {
         let message = MessageToDrone::Action(pending_action);

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -15,6 +15,7 @@ use std::{
     net::IpAddr,
     sync::{Arc, Mutex},
 };
+use valuable::Valuable;
 
 /// Clean up containers and images every minute.
 const CLEANUP_INTERVAL_SECS: i64 = 60;
@@ -183,6 +184,7 @@ impl Executor {
                     // We need to be careful here not to hold the lock when we call terminate, or
                     // else we can deadlock.
                     let Some(manager) = self.backends.get(backend_id) else {
+                        tracing::warn!(backend_id = backend_id.as_value(), "Backend not found when handling terminate action (assumed terminated).");
                         return Ok(());
                     };
                     manager.clone()


### PR DESCRIPTION
When the postgres connection pool reconnects, it's possible for events to be lost. This periodically checks for unacked messages and sends them to drones.