### PR TITLE
Cluster state endpoint

### DIFF
--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -5,10 +5,12 @@ use crate::{
     names::{BackendName, DroneName, Name, ProxyName},
     protocol::{CertManagerRequest, CertManagerResponse, MessageFromProxy, MessageToProxy},
     types::{
-        BackendStatus, ClusterName, ConnectRequest, ExecutorConfig, KeyConfig, Mount, SpawnConfig,
+        BackendStatus, ClusterName, ClusterState, ConnectRequest, ExecutorConfig, KeyConfig, Mount,
+        NodeState, SpawnConfig,
     },
     PLANE_GIT_HASH, PLANE_VERSION,
 };
+use chrono::Duration;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use url::Url;
@@ -148,6 +150,9 @@ pub enum AdminCommand {
         cluster: ClusterName,
     },
     Status,
+    ClusterState {
+        cluster: ClusterName,
+    },
 }
 
 pub async fn run_admin_command(opts: AdminOpts) {
@@ -343,7 +348,58 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
                 _ => panic!("Unexpected response"),
             }
         }
+        AdminCommand::ClusterState { cluster } => {
+            let cluster_state = client.cluster_state_url(&cluster).await?;
+            show_cluster_state(&cluster_state);
+        }
     };
 
     Ok(())
+}
+
+pub fn show_node_state(node: &NodeState) {
+    println!("  {}", node.name.to_string().bright_magenta());
+    println!("    Plane version: {}", node.plane_version);
+    println!("    Plane hash: {}", node.plane_hash);
+    println!("    Controller: {}", node.controller);
+    println!(
+        "    Controller heartbeat age: {}",
+        friendly_duration(node.controller_heartbeat_age)
+    );
+}
+
+pub fn show_cluster_state(cluster_state: &ClusterState) {
+    println!("{}", "Drones:".bright_yellow());
+    for drone in &cluster_state.drones {
+        show_node_state(&drone.node);
+        println!("    Ready: {}", drone.ready);
+        println!("    Draining: {}", drone.draining);
+        println!("    Backend count: {}", drone.backend_count);
+        println!(
+            "    Last heartbeat age: {}",
+            friendly_duration(drone.last_heartbeat_age)
+        );
+    }
+
+    println!("{}", "Proxies:".bright_yellow());
+    for proxy in &cluster_state.proxies {
+        show_node_state(&proxy);
+    }
+}
+
+pub fn friendly_duration(duration: Duration) -> String {
+    let seconds = duration.num_seconds();
+    let minutes = seconds / 60;
+    let hours = minutes / 60;
+    let days = hours / 24;
+
+    if days > 0 {
+        format!("{}d", days)
+    } else if hours > 0 {
+        format!("{}h", hours)
+    } else if minutes > 0 {
+        format!("{}m", minutes)
+    } else {
+        format!("{}s", seconds)
+    }
 }

--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     protocol::{MessageFromDns, MessageFromDrone, MessageFromProxy},
     typed_socket::client::TypedSocketConnector,
     types::{
-        backend_state::BackendStatusStreamEntry, ClusterName, ConnectRequest, ConnectResponse,
-        RevokeRequest,
+        backend_state::BackendStatusStreamEntry, ClusterName, ClusterState, ConnectRequest,
+        ConnectResponse, RevokeRequest,
     },
 };
 use reqwest::{Response, StatusCode};
@@ -181,6 +181,19 @@ impl PlaneClient {
 
         let stream = sse::sse_request(url, self.client.clone()).await?;
         Ok(stream)
+    }
+
+    pub async fn cluster_state_url(
+        &self,
+        cluster: &ClusterName,
+    ) -> Result<ClusterState, PlaneClientError> {
+        let url = self
+            .controller_address
+            .join(&format!("/ctrl/c/{}/state", cluster))
+            .url;
+        let response = self.client.get(url).send().await?;
+        let cluster_state: ClusterState = get_response(response).await?;
+        Ok(cluster_state)
     }
 }
 

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -1,5 +1,6 @@
 use self::{
     backend_state::{handle_backend_status, handle_backend_status_stream},
+    cluster_state::handle_cluster_state,
     connect::handle_revoke,
     dns::handle_dns_socket,
     drain::handle_drain,
@@ -38,6 +39,7 @@ use tracing::Level;
 use url::Url;
 
 mod backend_state;
+mod cluster_state;
 pub mod command;
 mod connect;
 mod core;
@@ -174,6 +176,7 @@ impl ControllerServer {
         // barrier (such as a reverse proxy) in front.
         let control_routes = Router::new()
             .route("/status", get(status))
+            .route("/c/:cluster/state", get(handle_cluster_state))
             .route("/c/:cluster/drone-socket", get(handle_drone_socket))
             .route("/c/:cluster/proxy-socket", get(handle_proxy_socket))
             .route("/dns-socket", get(handle_dns_socket))

--- a/plane/src/database/mod.rs
+++ b/plane/src/database/mod.rs
@@ -3,6 +3,7 @@ use self::{
     backend::BackendDatabase,
     backend_actions::BackendActionDatabase,
     backend_key::KeysDatabase,
+    cluster::ClusterDatabase,
     connect::ConnectError,
     controller::ControllerDatabase,
     drone::DroneDatabase,
@@ -22,6 +23,7 @@ pub mod acme;
 pub mod backend;
 pub mod backend_actions;
 pub mod backend_key;
+pub mod cluster;
 pub mod connect;
 pub mod controller;
 pub mod drone;
@@ -60,6 +62,10 @@ impl PlaneDatabase {
 
     pub fn drone(&self) -> DroneDatabase {
         DroneDatabase::new(&self.pool)
+    }
+
+    pub fn cluster(&self) -> ClusterDatabase {
+        ClusterDatabase::new(&self.pool)
     }
 
     pub fn node(&self) -> NodeDatabase {

--- a/plane/src/names.rs
+++ b/plane/src/names.rs
@@ -1,5 +1,6 @@
 use crate::types::NodeKind;
 use clap::error::ErrorKind;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 
 const MAX_NAME_LENGTH: usize = 45;
@@ -180,7 +181,7 @@ impl NodeName for AcmeDnsServerName {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AnyNodeName {
     Proxy(ProxyName),
     Drone(DroneName),

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -1,10 +1,11 @@
 use crate::{
     client::PlaneClient,
-    names::{BackendName, DroneName},
+    names::{AnyNodeName, BackendName, ControllerName, DroneName},
     util::{random_prefixed_string, random_token},
 };
 pub use backend_state::{BackendState, BackendStatus, TerminationKind, TerminationReason};
 use bollard::auth::DockerCredentials;
+use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
@@ -407,4 +408,30 @@ impl TryFrom<String> for NodeKind {
 pub struct RevokeRequest {
     pub backend_id: BackendName,
     pub user: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct DroneState {
+    pub ready: bool,
+    pub draining: bool,
+    #[serde(with = "crate::serialization::serialize_duration_as_seconds")]
+    pub last_heartbeat_age: Duration,
+    pub backend_count: u32,
+    pub node: NodeState,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct NodeState {
+    pub name: AnyNodeName,
+    pub plane_version: String,
+    pub plane_hash: String,
+    pub controller: ControllerName,
+    #[serde(with = "crate::serialization::serialize_duration_as_seconds")]
+    pub controller_heartbeat_age: Duration,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ClusterState {
+    pub drones: Vec<DroneState>,
+    pub proxies: Vec<NodeState>,
 }


### PR DESCRIPTION
This implements an API that returns cluster state, including:
- running proxies
- running drones, with draining state and number of active backends

Additionally, this is exposed via the CLI tool.