### PR TITLE
Cluster state API fixes

### DIFF
--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -359,7 +359,7 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
             }
         }
         AdminCommand::ClusterState { cluster } => {
-            let cluster_state = client.cluster_state_url(&cluster).await?;
+            let cluster_state = client.cluster_state(&cluster).await?;
             show_cluster_state(&cluster_state);
         }
     };

--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -189,10 +189,8 @@ impl PlaneClient {
     ) -> Result<ClusterState, PlaneClientError> {
         let url = self
             .controller_address
-            .join(&format!("/ctrl/c/{}/state", cluster))
-            .url;
-        let response = self.client.get(url).send().await?;
-        let cluster_state: ClusterState = get_response(response).await?;
+            .join(&format!("/ctrl/c/{}/state", cluster));
+        let cluster_state: ClusterState = authed_get(&self.client, &url).await?;
         Ok(cluster_state)
     }
 }

--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -183,7 +183,7 @@ impl PlaneClient {
         Ok(stream)
     }
 
-    pub async fn cluster_state_url(
+    pub async fn cluster_state(
         &self,
         cluster: &ClusterName,
     ) -> Result<ClusterState, PlaneClientError> {


### PR DESCRIPTION
This fixes two issues:

- The method name should not have `_url`
- The `Authorization` header should be sent