### PR TITLE
update idx_backend_drone_id

### DIFF
--- a/plane/schema/derived_schema.sql
+++ b/plane/schema/derived_schema.sql
@@ -912,7 +912,7 @@ CREATE INDEX idx_backend_action_pending ON public.backend_action USING btree (dr
 -- Name: idx_backend_drone_id; Type: INDEX; Schema: public; Owner: postgres
 --
 
-CREATE INDEX idx_backend_drone_id ON public.backend USING btree (cluster, drone_id) WHERE ((last_status)::text <> 'terminated'::text);
+CREATE INDEX idx_backend_drone_id ON public.backend USING btree (drone_id) WHERE ((last_status)::text <> 'terminated'::text);
 
 
 --

--- a/plane/schema/migrations/20240320144840_update-index-on-backend-table.sql
+++ b/plane/schema/migrations/20240320144840_update-index-on-backend-table.sql
@@ -1,0 +1,3 @@
+-- we don't query the backends by cluster and drone_id anymore, just by drone_id
+drop index idx_backend_drone_id;
+create index idx_backend_drone_id on backend(drone_id) where last_status != 'terminated';


### PR DESCRIPTION
I've noticed that the query for selecting a drone for scheduling can be quite slow due to an expensive sequence scan of the backend table. I also noticed that the index we have for that query includes the cluster, but the query doesn't. Would this updated index help speed this query up?