### PR TITLE
Delete drone.sqlite on postgres restart

### DIFF
--- a/dev/restart-postgres.sh
+++ b/dev/restart-postgres.sh
@@ -4,6 +4,7 @@ set -e
 
 docker stop postgres || true
 docker rm postgres || true
+rm -f "$(dirname "$0")/../drone.sqlite" || true
 
 docker run \
     -d \


### PR DESCRIPTION
`drone.sqlite` tracks backends that the drone starts. If you don't delete that when you restart the database, that database will have backends in it that no longer exist, so when it sends events about them the controller will not have seen those backends

Fixes error messages in the controller like:
```
Received backend event event=BackendStateMessage { event_id: BackendEventId(227), backend_id: BackendName("jykaswqmbiuaby"), state: {"status": "terminating", "last_status": "ready", "termination": TerminationKind::Soft, "reason": "key_expired"}, timestamp: ("2024-03-19 22:36:10.774 UTC",) }
2024-03-20T18:08:24.835791Z ERROR plane::controller::drone: Error handling message from drone err=error returned from database: insert or update on table "backend_state" violates foreign key constraint "backend_state_backend_id_fkey"

Caused by:
    insert or update on table "backend_state" violates foreign key constraint "backend_state_backend_id_fkey"
```