### PR TITLE
Add a failure to become ready timeout

### DIFF
--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -184,6 +184,7 @@ pub enum TerminationReason {
     External,
     KeyExpired,
     Lost,
+    StartupTimeout,
 }
 
 impl valuable::Valuable for TerminationReason {
@@ -193,12 +194,19 @@ impl valuable::Valuable for TerminationReason {
             TerminationReason::External => valuable::Value::String("external"),
             TerminationReason::KeyExpired => valuable::Value::String("key_expired"),
             TerminationReason::Lost => valuable::Value::String("lost"),
+            TerminationReason::StartupTimeout => valuable::Value::String("startup_timeout"),
         }
     }
 
     fn visit(&self, visit: &mut dyn valuable::Visit) {
         visit.visit_value(self.as_value())
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("Timeout waiting for backend to start")]
+    StartupTimeout,
 }
 
 impl BackendState {


### PR DESCRIPTION
Backend waits for server to start on 8080. Drone agent checks whether that container has a server running on 8080, but there's no timeout on that. Added a reasonable timeout (5min). If it trips that timeout, hard terminate the backend. Added a termination reason `TerminationReason::StartupTimeout`.