### PR TITLE
Fix WebSocket connection upgrade issue on Firefox

### DIFF
--- a/plane/src/proxy/rewriter.rs
+++ b/plane/src/proxy/rewriter.rs
@@ -145,7 +145,11 @@ impl RequestRewriter {
         let Ok(conn_header) = conn_header.to_str() else {
             return false;
         };
-        conn_header.to_lowercase() == "upgrade"
+
+        conn_header
+            .to_lowercase()
+            .split(',')
+            .any(|s| s.trim() == "upgrade")
     }
 }
 


### PR DESCRIPTION
Browsers are allowed to provide a comma-separated list in the `Connection` header, but we currently match on the exact string "upgrade", so this breaks. This change switches so that we check if _any_ of the values provided in the connection header match `upgrade`.

Closes #690 