### PR TITLE
allow soft terminating states to be followed by hard terminating states

### DIFF
--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -4,6 +4,7 @@ use self::{
 };
 use crate::{
     database::backend::BackendMetricsMessage,
+    heartbeat_consts::KILL_AFTER_SOFT_TERMINATE_SECONDS,
     names::BackendName,
     protocol::AcquiredKey,
     types::{BearerToken, ExecutorConfig},
@@ -11,7 +12,7 @@ use crate::{
 use anyhow::Result;
 use bollard::{
     auth::DockerCredentials,
-    container::{PruneContainersOptions, StatsOptions},
+    container::{PruneContainersOptions, StatsOptions, StopContainerOptions},
     errors::Error,
     image::PruneImagesOptions,
     service::{EventMessage, HostConfigLogConfig},
@@ -175,7 +176,12 @@ impl PlaneDocker {
                 .await?;
         } else {
             self.docker
-                .stop_container(&container_id.to_string(), None)
+                .stop_container(
+                    &container_id.to_string(),
+                    Some(StopContainerOptions {
+                        t: KILL_AFTER_SOFT_TERMINATE_SECONDS,
+                    }),
+                )
                 .await?;
         }
 

--- a/plane/src/heartbeat_consts.rs
+++ b/plane/src/heartbeat_consts.rs
@@ -31,9 +31,11 @@ pub const UNHEALTHY_SECONDS: i64 = 45;
 /// reassigned.
 pub const SOFT_TERMINATE_DEADLINE_SECONDS: i64 = 60;
 
-/// If a drone's lock message has not been confirmed in
-///
-pub const HARD_TERMINATE_DEADLINE_SECONDS: i64 = 90;
+/// Wait this many seconds after a soft terminate before
+/// killing the backend.
+pub const KILL_AFTER_SOFT_TERMINATE_SECONDS: i64 = 30;
+pub const HARD_TERMINATE_DEADLINE_SECONDS: i64 =
+    SOFT_TERMINATE_DEADLINE_SECONDS + KILL_AFTER_SOFT_TERMINATE_SECONDS;
 
 /// If we have not heard from a drone in this many seconds,
 /// we will consider it lost. This means that we will remove


### PR DESCRIPTION
This does two things:

1. Allows a soft terminating state to transition to a hard terminating state
2. Has the `stop_container` command only kill the backend after 30 seconds