### PR TITLE
Log unhandled errors

### DIFF
--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -33,6 +33,8 @@ pub const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The git hash of the plane binary (passed from build.rs)
 pub const PLANE_GIT_HASH: &str = env!("GIT_HASH");
 
+pub const SERVER_NAME: &str = concat!("Plane/", env!("CARGO_PKG_VERSION"));
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PlaneVersionInfo {
     pub version: String,

--- a/plane/src/lib.rs
+++ b/plane/src/lib.rs
@@ -33,7 +33,7 @@ pub const PLANE_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The git hash of the plane binary (passed from build.rs)
 pub const PLANE_GIT_HASH: &str = env!("GIT_HASH");
 
-pub const SERVER_NAME: &str = concat!("Plane/", env!("CARGO_PKG_VERSION"));
+pub const SERVER_NAME: &str = concat!("Plane/", env!("CARGO_PKG_VERSION"), "-", env!("GIT_HASH"));
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PlaneVersionInfo {

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -121,7 +121,7 @@ impl RequestHandler {
                     err => {
                         tracing::error!(?err, "Unhandled error handling request.");
                         (hyper::StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
-                    },
+                    }
                 };
                 Ok(hyper::Response::builder()
                     .status(status_code)

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -296,7 +296,7 @@ fn clone_response_empty_body(response: &Response<Body>) -> Response<Body> {
 
     builder = builder.status(response.status());
 
-    builder.body(Body::empty()).expect("Body is always valid.")
+    builder.body(Body::empty()).expect("Response is always valid.")
 }
 
 pub struct ProxyService {

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -221,7 +221,7 @@ impl RequestHandler {
         let mut response = if request_rewriter.should_upgrade() {
             let (req, req_clone) = request_rewriter.into_request_pair(&route_info);
             let response = self.state.http_client.request(req_clone).await?;
-            let response_clone = clone_response_empty_body(&response)?;
+            let response_clone = clone_response_empty_body(&response);
 
             let mut response_upgrade = hyper::upgrade::on(response).await?;
             let monitor = self.state.monitor.monitor();
@@ -286,7 +286,7 @@ impl RequestHandler {
     }
 }
 
-fn clone_response_empty_body(response: &Response<Body>) -> Result<Response<Body>, ProxyError> {
+fn clone_response_empty_body(response: &Response<Body>) -> Response<Body> {
     let mut builder = Response::builder();
 
     builder
@@ -296,7 +296,7 @@ fn clone_response_empty_body(response: &Response<Body>) -> Result<Response<Body>
 
     builder = builder.status(response.status());
 
-    Ok(builder.body(Body::empty()).expect("Body is always valid."))
+    builder.body(Body::empty()).expect("Body is always valid.")
 }
 
 pub struct ProxyService {

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -6,6 +6,7 @@ use super::{ForwardableRequestInfo, Protocol};
 use crate::proxy::cert_manager::CertWatcher;
 use crate::proxy::rewriter::RequestRewriter;
 use crate::proxy::tls::TlsAcceptor;
+use crate::SERVER_NAME;
 use axum::http::uri::PathAndQuery;
 use futures_util::{Future, FutureExt};
 use hyper::server::conn::AddrIncoming;
@@ -117,10 +118,14 @@ impl RequestHandler {
                         (hyper::StatusCode::UNAUTHORIZED, "Invalid subdomain")
                     }
                     ProxyError::BadRequest => (hyper::StatusCode::BAD_REQUEST, "Bad request"),
-                    _ => (hyper::StatusCode::INTERNAL_SERVER_ERROR, "Internal error"),
+                    err => {
+                        tracing::error!(?err, "Unhandled error handling request.");
+                        (hyper::StatusCode::INTERNAL_SERVER_ERROR, "Internal error")
+                    },
                 };
                 Ok(hyper::Response::builder()
                     .status(status_code)
+                    .header(hyper::header::SERVER, SERVER_NAME)
                     .body(hyper::Body::from(body.to_string()))
                     .expect("Static response is always valid"))
             }
@@ -136,10 +141,12 @@ impl RequestHandler {
             if self.state.connected() {
                 return Ok(hyper::Response::builder()
                     .status(hyper::StatusCode::OK)
+                    .header(hyper::header::SERVER, SERVER_NAME)
                     .body("Plane Proxy server (ready)".into())?);
             } else {
                 return Ok(hyper::Response::builder()
                     .status(hyper::StatusCode::SERVICE_UNAVAILABLE)
+                    .header(hyper::header::SERVER, SERVER_NAME)
                     .body("Plane Proxy server (not ready)".into())?);
             }
         }
@@ -163,6 +170,7 @@ impl RequestHandler {
             return Ok(hyper::Response::builder()
                 .status(hyper::StatusCode::MOVED_PERMANENTLY)
                 .header(hyper::header::LOCATION, uri.to_string())
+                .header(hyper::header::SERVER, SERVER_NAME)
                 .body(hyper::Body::empty())?);
         }
 
@@ -171,6 +179,7 @@ impl RequestHandler {
                 return Ok(hyper::Response::builder()
                     .status(hyper::StatusCode::MOVED_PERMANENTLY)
                     .header(hyper::header::LOCATION, root_redirect_url.to_string())
+                    .header(hyper::header::SERVER, SERVER_NAME)
                     .body(hyper::Body::empty())?);
             }
         }
@@ -287,7 +296,7 @@ fn clone_response_empty_body(response: &Response<Body>) -> Result<Response<Body>
 
     builder = builder.status(response.status());
 
-    Ok(builder.body(Body::empty())?)
+    Ok(builder.body(Body::empty()).expect("Body is always valid."))
 }
 
 pub struct ProxyService {

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -296,7 +296,9 @@ fn clone_response_empty_body(response: &Response<Body>) -> Response<Body> {
 
     builder = builder.status(response.status());
 
-    builder.body(Body::empty()).expect("Response is always valid.")
+    builder
+        .body(Body::empty())
+        .expect("Response is always valid.")
 }
 
 pub struct ProxyService {


### PR DESCRIPTION
- If we return an internal error, log it.
- On requests that Plane handles internally (non-proxied requests), return a server header that includes the version number.