### PR TITLE
Return GONE on terminated backend

### DIFF
--- a/plane/.sqlx/query-40cab83a74ad43beb3c150f6f14496cfe9fbe4a7a2253bc38da68cc31007d318.json
+++ b/plane/.sqlx/query-40cab83a74ad43beb3c150f6f14496cfe9fbe4a7a2253bc38da68cc31007d318.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            left join backend\n            on backend.id = token.backend_id\n            and backend.last_status = $2\n            where token = $1\n            limit 1\n            ",
+  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            inner join backend\n            on backend.id = token.backend_id\n            and backend.last_status = $2\n            where token = $1\n            limit 1\n            ",
   "describe": {
     "columns": [
       {
@@ -61,5 +61,5 @@
       true
     ]
   },
-  "hash": "f88fe0f0f1812332e135e2c543a9dbd0817d260d60ffadc9ccb967869e222840"
+  "hash": "40cab83a74ad43beb3c150f6f14496cfe9fbe4a7a2253bc38da68cc31007d318"
 }

--- a/plane/.sqlx/query-f88fe0f0f1812332e135e2c543a9dbd0817d260d60ffadc9ccb967869e222840.json
+++ b/plane/.sqlx/query-f88fe0f0f1812332e135e2c543a9dbd0817d260d60ffadc9ccb967869e222840.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            left join backend\n            on backend.id = token.backend_id\n            where token = $1\n            limit 1\n            ",
+  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            left join backend\n            on backend.id = token.backend_id\n            and backend.last_status = $2\n            where token = $1\n            limit 1\n            ",
   "describe": {
     "columns": [
       {
@@ -46,6 +46,7 @@
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Text"
       ]
     },
@@ -60,5 +61,5 @@
       true
     ]
   },
-  "hash": "99b7c7c7eb677ac7c8406d67c18507ce4ce01ecccac39ba8b76273e56795a2fa"
+  "hash": "f88fe0f0f1812332e135e2c543a9dbd0817d260d60ffadc9ccb967869e222840"
 }

--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -133,7 +133,6 @@ pub enum AdminCommand {
         subdomain: Option<Subdomain>,
     },
     Terminate {
-        #[clap(long)]
         backend: BackendName,
 
         #[clap(long)]

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -345,7 +345,7 @@ impl<'a> BackendDatabase<'a> {
                 secret_token,
                 subdomain
             from token
-            left join backend
+            inner join backend
             on backend.id = token.backend_id
             and backend.last_status = $2
             where token = $1

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -347,10 +347,12 @@ impl<'a> BackendDatabase<'a> {
             from token
             left join backend
             on backend.id = token.backend_id
+            and backend.last_status = $2
             where token = $1
             limit 1
             "#,
             token.to_string(),
+            BackendStatus::Ready.to_string(),
         )
         .fetch_optional(&self.db.pool)
         .await?;

--- a/plane/src/protocol.rs
+++ b/plane/src/protocol.rs
@@ -202,6 +202,7 @@ impl ChannelMessage for MessageFromProxy {
 pub enum MessageToProxy {
     RouteInfoResponse(RouteInfoResponse),
     CertManagerResponse(CertManagerResponse),
+    BackendRemoved { backend: BackendName },
 }
 
 impl ChannelMessage for MessageToProxy {

--- a/plane/src/proxy/proxy_connection.rs
+++ b/plane/src/proxy/proxy_connection.rs
@@ -70,6 +70,7 @@ impl ProxyConnection {
                                     backend = backend.as_value(),
                                     "Received backend removed message."
                                 );
+                                state.route_map.remove_backend(&backend);
                             }
                         }
                     }

--- a/plane/src/proxy/proxy_connection.rs
+++ b/plane/src/proxy/proxy_connection.rs
@@ -66,7 +66,10 @@ impl ProxyConnection {
                                 cert_manager.receive(response);
                             }
                             MessageToProxy::BackendRemoved { backend } => {
-                                tracing::info!(backend = backend.as_value(), "Received backend removed message.");
+                                tracing::info!(
+                                    backend = backend.as_value(),
+                                    "Received backend removed message."
+                                );
                             }
                         }
                     }

--- a/plane/src/proxy/proxy_connection.rs
+++ b/plane/src/proxy/proxy_connection.rs
@@ -65,6 +65,9 @@ impl ProxyConnection {
                                 );
                                 cert_manager.receive(response);
                             }
+                            MessageToProxy::BackendRemoved { backend } => {
+                                tracing::info!(backend = backend.as_value(), "Received backend removed message.");
+                            }
                         }
                     }
 

--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -117,9 +117,10 @@ impl RequestHandler {
             Ok(response) => Ok(response),
             Err(err) => {
                 let (status_code, body) = match err {
-                    ProxyError::InvalidConnectionToken => {
-                        (hyper::StatusCode::FORBIDDEN, "Forbidden")
-                    }
+                    ProxyError::InvalidConnectionToken => (
+                        hyper::StatusCode::GONE,
+                        "The backend is no longer available or the connection token is invalid.",
+                    ),
                     ProxyError::MissingHostHeader => {
                         (hyper::StatusCode::BAD_REQUEST, "Bad request")
                     }

--- a/plane/src/proxy/route_map.rs
+++ b/plane/src/proxy/route_map.rs
@@ -1,5 +1,7 @@
 use crate::{
-    names::BackendName, protocol::{RouteInfo, RouteInfoRequest, RouteInfoResponse}, types::BearerToken
+    names::BackendName,
+    protocol::{RouteInfo, RouteInfoRequest, RouteInfoResponse},
+    types::BearerToken,
 };
 use lru::LruCache;
 use std::{


### PR DESCRIPTION
- `route_info_for_token` returns `None` if the backend is not ready
- adds `MessageToProxy::BackendRemoved` variant. This will be used for the controller to notify drones when a backend has been terminated, and tells it to invalidate any connection tokens associated with that backend. This is not currently sent from the controller yet, but will be in a future PR.
- Modifies handling of `InvalidConnectionToken` to return `GONE` instead of `FORBIDDEN`.

Fixes DIS-1891

