### PR TITLE
Only strip port if it's 443

### DIFF
--- a/plane/src/proxy/rewriter.rs
+++ b/plane/src/proxy/rewriter.rs
@@ -105,6 +105,11 @@ impl RequestRewriter {
         };
 
         // Remove port from hostname if present and port is 443.
+        // We are already a bit magic with regards to HTTP/HTTPS: we assume that if a
+        // cluster name has a colon, it's HTTP and runs on that port, and if a cluster
+        // name does not have a colon, it is HTTPS and runs on 443. In other words,
+        // in production, there's no way for URLs generated and sent to clients to have
+        // a port other than the standard HTTPS port 443.
         let hostname = if let Some(hostname) = hostname.strip_suffix(":443") {
             hostname
         } else {

--- a/plane/src/proxy/rewriter.rs
+++ b/plane/src/proxy/rewriter.rs
@@ -104,10 +104,11 @@ impl RequestRewriter {
             }
         };
 
-        // Remove port from hostname if present.
-        let hostname = match hostname.split_once(':') {
-            Some((hostname, _)) => hostname,
-            None => hostname,
+        // Remove port from hostname if present and port is 443.
+        let hostname = if let Some(hostname) = hostname.strip_suffix(":443") {
+            hostname
+        } else {
+            hostname
         };
 
         let Some(subdomain) = hostname.strip_suffix(cluster.as_str()) else {


### PR DESCRIPTION
Stripping all ports breaks the default cluster for localhost testing, `localhost:9090`.

We are already a bit magic with regards to http/https. We assume that if a cluster name has a colon, it's HTTP and runs on that port, and if a cluster name does not have a colon, it is HTTPS and runs on 443. In other words, in production, there's no way for URLs generated and sent to clients to have a port other than the standard HTTPS port 443.

(The https server can run on another port locally, as long as the ultimate client connecting to it is connecting to port 443.)