### PR TITLE
Add backend ID to forwarded request headers.

### DIFF
--- a/plane/src/proxy/rewriter.rs
+++ b/plane/src/proxy/rewriter.rs
@@ -17,6 +17,7 @@ const USERNAME_HEADER: &str = "x-verified-username";
 const AUTH_SECRET_HEADER: &str = "x-verified-secret";
 const AUTH_USER_DATA_HEADER: &str = "x-verified-user-data";
 const PATH_PREFIX_HEADER: &str = "x-verified-path";
+const BACKEND_ID_HEADER: &str = "x-verified-backend";
 const X_FORWARDED_FOR_HEADER: &str = "x-forwarded-for";
 const X_FORWARDED_PROTO_HEADER: &str = "x-forwarded-proto";
 
@@ -294,5 +295,14 @@ fn set_headers_from_route_info(
     headers.insert(
         PATH_PREFIX_HEADER,
         HeaderValue::from_str(&prefix_uri.to_string()).expect("Path is valid."),
+    );
+
+    headers.insert(
+        BACKEND_ID_HEADER,
+        route_info
+            .backend_id
+            .to_string()
+            .parse()
+            .expect("Backend ID is a valid header value."),
     );
 }


### PR DESCRIPTION
This adds the header `x-verified-backend` header to requests that get sent to a backend.

This is in support of #712. With the Docker executor, we use the operating system's port mappings to dispatch a request to the right process. With alternate executors, the executor itself may want to provide the HTTP server and dispatch to the appropriate backend. This header gives them that option.

<img width="581" alt="image" src="https://github.com/drifting-in-space/plane/assets/46173/d15f5f80-4072-408d-b7f0-2e0eff8865fe">
