### PR TITLE
Turn executor config into an enum

### DIFF
--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -7,7 +7,7 @@ use plane::{
     controller::ControllerServer,
     database::PlaneDatabase,
     dns::run_dns_with_listener,
-    drone::{docker::PlaneDockerConfig, Drone, DroneConfig},
+    drone::{docker::PlaneDockerConfig, Drone, DroneConfig, ExecutorConfig},
     names::{AcmeDnsServerName, ControllerName, DroneName, Name},
     proxy::AcmeEabConfiguration,
     types::{ClusterName, DronePoolName},
@@ -119,6 +119,7 @@ impl TestEnvironment {
             mount_base: mount_base.map(|p| p.to_owned()),
         };
 
+        #[allow(deprecated)] // `docker_config` field is deprecated.
         let drone_config = DroneConfig {
             name: DroneName::new_random(),
             cluster: TEST_CLUSTER.parse().unwrap(),
@@ -127,7 +128,8 @@ impl TestEnvironment {
             pool: pool.clone(),
             auto_prune: false,
             cleanup_min_age: Duration::zero(),
-            docker_config,
+            executor_config: Some(ExecutorConfig::Docker(docker_config)),
+            docker_config: None,
             controller_url: controller.url().clone(),
         };
 

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -10,6 +10,8 @@ use clap::Parser;
 use std::{net::IpAddr, path::PathBuf};
 use url::Url;
 
+use super::ExecutorConfig;
+
 #[derive(Parser)]
 pub struct DroneOpts {
     #[clap(long)]
@@ -78,6 +80,7 @@ impl DroneOpts {
             Duration::try_seconds(self.auto_prune_containers_older_than_seconds as i64)
                 .expect("valid duration");
 
+        #[allow(deprecated)] // `docker_config` field is deprecated.
         let drone_config = DroneConfig {
             controller_url: self.controller_url,
             name: name.clone(),
@@ -87,7 +90,8 @@ impl DroneOpts {
             pool: self.pool,
             auto_prune: self.auto_prune_images,
             cleanup_min_age,
-            docker_config,
+            docker_config: None,
+            executor_config: Some(ExecutorConfig::Docker(docker_config)),
         };
 
         Ok(drone_config)


### PR DESCRIPTION
In service of #712, this makes the type of executor configurable in Plane. Since the executor itself isn't generic yet, docker is the only supported type.

This is a change to the configuration schema, in a way that is backwards-compatible for now. Eventually, the `docker_config` config field (which this change deprecates) will be removed.