### PR TITLE
Move `prune` into PlaneDocker executor

### DIFF
--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -117,6 +117,8 @@ impl TestEnvironment {
             runtime: None,
             log_config: None,
             mount_base: mount_base.map(|p| p.to_owned()),
+            auto_prune: Some(false),
+            cleanup_min_age: Some(Duration::zero()),
         };
 
         #[allow(deprecated)] // `docker_config` field is deprecated.
@@ -126,8 +128,8 @@ impl TestEnvironment {
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
             db_path: Some(self.scratch_dir.join("drone.db")),
             pool: pool.clone(),
-            auto_prune: false,
-            cleanup_min_age: Duration::zero(),
+            auto_prune: None,
+            cleanup_min_age: None,
             executor_config: Some(ExecutorConfig::Docker(docker_config)),
             docker_config: None,
             controller_url: controller.url().clone(),

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -67,20 +67,22 @@ impl DroneOpts {
             .map(|s| serde_json::from_str(&s))
             .transpose()?;
 
+        let cleanup_min_age =
+            Duration::try_seconds(self.auto_prune_containers_older_than_seconds as i64)
+                .expect("valid duration");
+
         let docker_config = PlaneDockerConfig {
             runtime: self.docker_runtime,
             log_config,
             mount_base: self.mount_base,
+            auto_prune: Some(self.auto_prune_images),
+            cleanup_min_age: Some(cleanup_min_age),
         };
 
         let ip: IpAddr = resolve_hostname(&self.ip)
             .ok_or_else(|| anyhow::anyhow!("Failed to resolve hostname to IP address."))?;
 
-        let cleanup_min_age =
-            Duration::try_seconds(self.auto_prune_containers_older_than_seconds as i64)
-                .expect("valid duration");
-
-        #[allow(deprecated)] // `docker_config` field is deprecated.
+        #[allow(deprecated)]
         let drone_config = DroneConfig {
             controller_url: self.controller_url,
             name: name.clone(),
@@ -88,9 +90,9 @@ impl DroneOpts {
             ip,
             db_path: self.db,
             pool: self.pool,
-            auto_prune: self.auto_prune_images,
-            cleanup_min_age,
-            docker_config: None,
+            auto_prune: None,      // deprecated
+            cleanup_min_age: None, // deprecated
+            docker_config: None,   // deprecated
             executor_config: Some(ExecutorConfig::Docker(docker_config)),
         };
 

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     names::BackendName,
     protocol::AcquiredKey,
     types::{BearerToken, DockerExecutorConfig},
+    util::GuardHandle,
 };
 use anyhow::Result;
 use bollard::{
@@ -19,13 +20,19 @@ use bollard::{
     system::EventsOptions,
     Docker,
 };
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::{collections::HashMap, path::PathBuf};
 use thiserror::Error;
 use tokio_stream::{Stream, StreamExt};
 use valuable::Valuable;
+
+/// Clean up containers and images every minute.
+const CLEANUP_INTERVAL_SECS: i64 = 60;
 
 pub mod commands;
 pub mod types;
@@ -39,12 +46,17 @@ pub struct PlaneDockerConfig {
     pub runtime: Option<String>,
     pub log_config: Option<HostConfigLogConfig>,
     pub mount_base: Option<PathBuf>,
+
+    pub auto_prune: Option<bool>,
+    #[serde(with = "crate::serialization::serialize_optional_duration_as_seconds")]
+    pub cleanup_min_age: Option<Duration>,
 }
 
 #[derive(Clone, Debug)]
 pub struct PlaneDocker {
     docker: Docker,
     config: PlaneDockerConfig,
+    _cleanup_handle: Arc<GuardHandle>,
 }
 
 #[derive(Clone, Debug)]
@@ -60,7 +72,28 @@ pub struct SpawnResult {
 
 impl PlaneDocker {
     pub async fn new(docker: Docker, config: PlaneDockerConfig) -> Result<Self> {
-        Ok(Self { docker, config })
+        let cleanup_handle = {
+            let docker = docker.clone();
+            let cleanup_min_age = config.cleanup_min_age.unwrap_or_default();
+            let auto_prune = config.auto_prune.unwrap_or_default();
+            GuardHandle::new(async move {
+                cleanup_loop(
+                    docker.clone(),
+                    cleanup_min_age,
+                    Duration::try_seconds(CLEANUP_INTERVAL_SECS).expect("duration is always valid"),
+                    auto_prune,
+                )
+                .await;
+            })
+        };
+
+        let cleanup_handle = Arc::new(cleanup_handle);
+
+        Ok(Self {
+            docker,
+            config,
+            _cleanup_handle: cleanup_handle,
+        })
     }
 
     pub async fn pull(
@@ -204,60 +237,6 @@ impl PlaneDocker {
             .ok_or(anyhow::anyhow!("no stats found for {container_id}"))?
             .map_err(|e| anyhow::anyhow!("{e:?}"))
     }
-
-    /// Prune stopped backend containers that are older than the prune threshold.
-    /// Then, (optionally) remove unused images also older than the prune threshold.
-    pub async fn prune(&self, until: DateTime<Utc>, prune_images: bool) -> Result<()> {
-        tracing::info!("Pruning Docker containers and images.");
-
-        let since_unixtime = until.timestamp();
-        let filters: HashMap<String, Vec<String>> = vec![
-            ("until".to_string(), vec![since_unixtime.to_string()]),
-            ("label".to_string(), vec![PLANE_DOCKER_LABEL.to_string()]),
-        ]
-        .into_iter()
-        .collect();
-
-        match self
-            .docker
-            .prune_containers(Some(PruneContainersOptions {
-                filters: filters.clone(),
-            }))
-            .await
-        {
-            Ok(result) => {
-                let num_containers_deleted =
-                    result.containers_deleted.map(|d| d.len()).unwrap_or(0);
-                let space_reclaimed_bytes = result.space_reclaimed;
-                tracing::info!(
-                    num_containers_deleted,
-                    space_reclaimed_bytes,
-                    "Done pruning containers."
-                );
-            }
-            Err(e) => tracing::error!(?e, "Error pruning containers."),
-        }
-
-        if prune_images {
-            let filters: HashMap<String, Vec<String>> =
-                vec![("until".to_string(), vec![since_unixtime.to_string()])]
-                    .into_iter()
-                    .collect();
-            match self
-                .docker
-                .prune_images(Some(PruneImagesOptions { filters }))
-                .await
-            {
-                Ok(result) => {
-                    let num_images_deleted = result.images_deleted.map(|d| d.len()).unwrap_or(0);
-                    tracing::info!(num_images_deleted, "Pruning images.");
-                }
-                Err(e) => tracing::error!(?e, "Error pruning images."),
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[derive(Error, Debug)]
@@ -371,4 +350,72 @@ pub fn get_metrics_message_from_container_stats(
         cpu_used: container_cpu_used_delta,
         sys_cpu: system_cpu_used_delta,
     })
+}
+
+async fn cleanup_loop(docker: Docker, min_age: Duration, interval: Duration, auto_prune: bool) {
+    loop {
+        tokio::time::sleep(
+            interval
+                .to_std()
+                .expect("Expected interval to convert to std."),
+        )
+        .await;
+
+        let since = Utc::now() - min_age;
+
+        if let Err(e) = prune(&docker, since, auto_prune).await {
+            tracing::error!(?e, "Error pruning Docker containers and images.");
+        }
+    }
+}
+
+/// Prune stopped backend containers that are older than the prune threshold.
+/// Then, (optionally) remove unused images also older than the prune threshold.
+pub async fn prune(docker: &Docker, until: DateTime<Utc>, prune_images: bool) -> Result<()> {
+    tracing::info!("Pruning Docker containers and images.");
+
+    let since_unixtime = until.timestamp();
+    let filters: HashMap<String, Vec<String>> = vec![
+        ("until".to_string(), vec![since_unixtime.to_string()]),
+        ("label".to_string(), vec![PLANE_DOCKER_LABEL.to_string()]),
+    ]
+    .into_iter()
+    .collect();
+
+    match docker
+        .prune_containers(Some(PruneContainersOptions {
+            filters: filters.clone(),
+        }))
+        .await
+    {
+        Ok(result) => {
+            let num_containers_deleted = result.containers_deleted.map(|d| d.len()).unwrap_or(0);
+            let space_reclaimed_bytes = result.space_reclaimed;
+            tracing::info!(
+                num_containers_deleted,
+                space_reclaimed_bytes,
+                "Done pruning containers."
+            );
+        }
+        Err(e) => tracing::error!(?e, "Error pruning containers."),
+    }
+
+    if prune_images {
+        let filters: HashMap<String, Vec<String>> =
+            vec![("until".to_string(), vec![since_unixtime.to_string()])]
+                .into_iter()
+                .collect();
+        match docker
+            .prune_images(Some(PruneImagesOptions { filters }))
+            .await
+        {
+            Ok(result) => {
+                let num_images_deleted = result.images_deleted.map(|d| d.len()).unwrap_or(0);
+                tracing::info!(num_images_deleted, "Pruning images.");
+            }
+            Err(e) => tracing::error!(?e, "Error pruning images."),
+        }
+    }
+
+    Ok(())
 }

--- a/plane/src/serialization.rs
+++ b/plane/src/serialization.rs
@@ -17,3 +17,31 @@ pub mod serialize_duration_as_seconds {
         Ok(Duration::try_seconds(seconds).expect("valid duration"))
     }
 }
+
+pub mod serialize_optional_duration_as_seconds {
+    use chrono::Duration;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(duration: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match duration {
+            Some(duration) => serializer.serialize_i64(duration.num_seconds()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let seconds: Option<i64> = Deserialize::deserialize(deserializer)?;
+        match seconds {
+            Some(seconds) => Ok(Some(
+                Duration::try_seconds(seconds).expect("valid duration"),
+            )),
+            None => Ok(None),
+        }
+    }
+}


### PR DESCRIPTION
`PlaneDocker` exposes a method `prune` which is run on a cleanup loop. The specifics of this cleanup are an implementation detail that only the Docker executor cares about. Since we want to move towards `PlaneDocker` implementing a generic, executor-agnostic trait, we want to eliminate this.

The approach here is to move the pruning loop into the PlaneExecutor itself. The loop starts when the executor is constructed, and runs until it is dropped.

In order to facilitate this, the configuration for pruning has to be moved into the executor config instead of the general drone config, which this PR also does.

Part of #712 