### PR TITLE
Move Docker construction into PlaneDocker

### DIFF
--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -14,8 +14,7 @@ mod common;
 
 #[plane_test]
 async fn test_get_metrics(_: TestEnvironment) {
-    let docker = bollard::Docker::connect_with_local_defaults().unwrap();
-    let plane_docker = PlaneDocker::new(docker, PlaneDockerConfig::default())
+    let plane_docker = PlaneDocker::new(PlaneDockerConfig::default())
         .await
         .unwrap();
 

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -71,7 +71,9 @@ pub struct SpawnResult {
 }
 
 impl PlaneDocker {
-    pub async fn new(docker: Docker, config: PlaneDockerConfig) -> Result<Self> {
+    pub async fn new(config: PlaneDockerConfig) -> Result<Self> {
+        let docker = Docker::connect_with_local_defaults()?;
+
         let cleanup_handle = {
             let docker = docker.clone();
             let cleanup_min_age = config.cleanup_min_age.unwrap_or_default();

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     types::{BackendState, ClusterName, DronePoolName},
 };
 use anyhow::{anyhow, Result};
-use bollard::Docker;
 use chrono::{Duration, Utc};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -184,14 +183,14 @@ impl Drone {
                 docker_config.cleanup_min_age =
                     docker_config.cleanup_min_age.or(config.cleanup_min_age);
 
-                PlaneDocker::new(Docker::connect_with_local_defaults()?, docker_config).await?
+                PlaneDocker::new(docker_config).await?
             }
             (None, Some(ExecutorConfig::Docker(mut docker_config))) => {
                 docker_config.auto_prune = docker_config.auto_prune.or(config.auto_prune);
                 docker_config.cleanup_min_age =
                     docker_config.cleanup_min_age.or(config.cleanup_min_age);
 
-                PlaneDocker::new(Docker::connect_with_local_defaults()?, docker_config).await?
+                PlaneDocker::new(docker_config).await?
             }
             (None, None) => {
                 tracing::error!("Neither `docker_config` nor `executor_config` provided.");


### PR DESCRIPTION
We currently open the connection to Docker outside of the `PlaneDocker` instance, and pass it in during construction. This means it has to be part of the interface, which means we can't make it generic. This moves the connection to Docker into the `PlaneDocker` instance (prereq for #712).