### PR TITLE
Rename PlaneDocker to DockerRuntime

### DIFF
--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -7,7 +7,7 @@ use plane::{
     controller::ControllerServer,
     database::PlaneDatabase,
     dns::run_dns_with_listener,
-    drone::{docker::PlaneDockerConfig, Drone, DroneConfig, ExecutorConfig},
+    drone::{docker::DockerRuntimeConfig, Drone, DroneConfig, ExecutorConfig},
     names::{AcmeDnsServerName, ControllerName, DroneName, Name},
     proxy::AcmeEabConfiguration,
     types::{ClusterName, DronePoolName},
@@ -113,7 +113,7 @@ impl TestEnvironment {
         pool: &DronePoolName,
         mount_base: Option<&PathBuf>,
     ) -> Drone {
-        let docker_config = PlaneDockerConfig {
+        let docker_config = DockerRuntimeConfig {
             runtime: None,
             log_config: None,
             mount_base: mount_base.map(|p| p.to_owned()),

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -1,8 +1,8 @@
 use common::test_env::TestEnvironment;
 use plane::{
     drone::docker::{
-        get_metrics_message_from_container_stats, types::ContainerId, MetricsConversionError,
-        PlaneDocker, PlaneDockerConfig,
+        get_metrics_message_from_container_stats, types::ContainerId, DockerRuntime,
+        DockerRuntimeConfig, MetricsConversionError,
     },
     names::{BackendName, Name},
     types::DockerExecutorConfig,
@@ -14,7 +14,7 @@ mod common;
 
 #[plane_test]
 async fn test_get_metrics(_: TestEnvironment) {
-    let plane_docker = PlaneDocker::new(PlaneDockerConfig::default())
+    let plane_docker = DockerRuntime::new(DockerRuntimeConfig::default())
         .await
         .unwrap();
 

--- a/plane/src/drone/backend_manager.rs
+++ b/plane/src/drone/backend_manager.rs
@@ -1,5 +1,5 @@
 use super::{
-    docker::{get_metrics_message_from_container_stats, types::ContainerId, PlaneDocker},
+    docker::{get_metrics_message_from_container_stats, types::ContainerId, DockerRuntime},
     wait_backend::wait_for_backend,
 };
 use crate::{
@@ -52,7 +52,7 @@ type StateCallback = Box<dyn Fn(&BackendState) -> Result<(), Box<dyn Error>> + S
 struct MetricsManager {
     handle: Mutex<Option<GuardHandle>>,
     sender: Arc<RwLock<TypedSocketSender<BackendMetricsMessage>>>,
-    docker: PlaneDocker,
+    docker: DockerRuntime,
     container_id: ContainerId,
     backend_id: BackendName,
     prev_container_cpu_cumulative_ns: Arc<AtomicU64>,
@@ -62,7 +62,7 @@ struct MetricsManager {
 impl MetricsManager {
     fn new(
         sender: Arc<RwLock<TypedSocketSender<BackendMetricsMessage>>>,
-        docker: PlaneDocker,
+        docker: DockerRuntime,
         container_id: ContainerId,
         backend_id: BackendName,
     ) -> Self {
@@ -135,7 +135,7 @@ pub struct BackendManager {
     backend_id: BackendName,
 
     /// The Docker client to use for all Docker operations.
-    docker: PlaneDocker,
+    docker: DockerRuntime,
 
     /// The configuration to use when spawning the backend.
     executor_config: DockerExecutorConfig,
@@ -171,7 +171,7 @@ impl BackendManager {
         backend_id: BackendName,
         executor_config: DockerExecutorConfig,
         state: BackendState,
-        docker: PlaneDocker,
+        docker: DockerRuntime,
         state_callback: impl Fn(&BackendState) -> Result<(), Box<dyn Error>> + Send + Sync + 'static,
         metrics_sender: Arc<RwLock<TypedSocketSender<BackendMetricsMessage>>>,
         ip: IpAddr,

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    drone::{docker::PlaneDockerConfig, DroneConfig},
+    drone::{docker::DockerRuntimeConfig, DroneConfig},
     names::{DroneName, OrRandom},
     types::{ClusterName, DronePoolName},
     util::resolve_hostname,
@@ -71,7 +71,7 @@ impl DroneOpts {
             Duration::try_seconds(self.auto_prune_containers_older_than_seconds as i64)
                 .expect("valid duration");
 
-        let docker_config = PlaneDockerConfig {
+        let docker_config = DockerRuntimeConfig {
             runtime: self.docker_runtime,
             log_config,
             mount_base: self.mount_base,

--- a/plane/src/drone/docker/commands.rs
+++ b/plane/src/drone/docker/commands.rs
@@ -1,4 +1,4 @@
-use super::{types::ContainerId, PlaneDocker};
+use super::{types::ContainerId, DockerRuntime};
 use crate::{
     names::BackendName,
     protocol::AcquiredKey,
@@ -256,7 +256,7 @@ pub fn get_container_config_from_executor_config(
 }
 
 pub async fn run_container(
-    docker: &PlaneDocker,
+    docker: &DockerRuntime,
     backend_id: &BackendName,
     container_id: &ContainerId,
     exec_config: DockerExecutorConfig,

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -42,7 +42,7 @@ pub mod types;
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct PlaneDockerConfig {
+pub struct DockerRuntimeConfig {
     pub runtime: Option<String>,
     pub log_config: Option<HostConfigLogConfig>,
     pub mount_base: Option<PathBuf>,
@@ -53,9 +53,9 @@ pub struct PlaneDockerConfig {
 }
 
 #[derive(Clone, Debug)]
-pub struct PlaneDocker {
+pub struct DockerRuntime {
     docker: Docker,
-    config: PlaneDockerConfig,
+    config: DockerRuntimeConfig,
     _cleanup_handle: Arc<GuardHandle>,
 }
 
@@ -70,8 +70,8 @@ pub struct SpawnResult {
     pub port: u16,
 }
 
-impl PlaneDocker {
-    pub async fn new(config: PlaneDockerConfig) -> Result<Self> {
+impl DockerRuntime {
+    pub async fn new(config: DockerRuntimeConfig) -> Result<Self> {
         let docker = Docker::connect_with_local_defaults()?;
 
         let cleanup_handle = {

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -1,4 +1,4 @@
-use super::{backend_manager::BackendManager, docker::PlaneDocker, state_store::StateStore};
+use super::{backend_manager::BackendManager, docker::DockerRuntime, state_store::StateStore};
 use crate::{
     database::backend::BackendMetricsMessage,
     names::BackendName,
@@ -17,7 +17,7 @@ use std::{
 use valuable::Valuable;
 
 pub struct Executor {
-    docker: PlaneDocker,
+    docker: DockerRuntime,
     state_store: Arc<Mutex<StateStore>>,
     backends: Arc<DashMap<BackendName, Arc<BackendManager>>>,
     ip: IpAddr,
@@ -25,7 +25,7 @@ pub struct Executor {
 }
 
 impl Executor {
-    pub fn new(docker: PlaneDocker, state_store: StateStore, ip: IpAddr) -> Self {
+    pub fn new(docker: DockerRuntime, state_store: StateStore, ip: IpAddr) -> Self {
         let backends: Arc<DashMap<BackendName, Arc<BackendManager>>> = Arc::default();
 
         let backend_event_listener = {


### PR DESCRIPTION
I want to create some clarity around terminology in Plane as we move towards generic runtimes (#712):

- **Executor** refers to the generic piece that manages the backend lifecycle
- **Runtime** refers to the code that actually manages the backends

So for Docker, `DockerRuntime` will implement the (as-yet-unimplemented) `Runtime` trait, an instance of which will be owned and managed by the `Executor`.

This moves towards using that terminology. I created it as a standalone PR because it would add a bunch of noise if I did it alongside other changes. All this PR does is:

- Replace `PlaneDocker` with `DockerRuntime`
- Replace `PlaneDockerConfig` with `DockerRuntimeConfig`
- Update a couple of comments