### PR TITLE
Remove ContainerId from runtime interface

### DIFF
--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -1,8 +1,8 @@
 use common::test_env::TestEnvironment;
 use plane::{
     drone::docker::{
-        get_metrics_message_from_container_stats, types::ContainerId, DockerRuntime,
-        DockerRuntimeConfig, MetricsConversionError,
+        get_metrics_message_from_container_stats, DockerRuntime, DockerRuntimeConfig,
+        MetricsConversionError,
     },
     names::{BackendName, Name},
     types::DockerExecutorConfig,
@@ -29,16 +29,15 @@ async fn test_get_metrics(_: TestEnvironment) {
         .unwrap();
 
     let backend_name = BackendName::new_random();
-    let container_id = ContainerId::from(format!("plane-test-{}", backend_name));
     let executor_config = DockerExecutorConfig::from_image_with_defaults(
         "ghcr.io/drifting-in-space/demo-image-drop-four",
     );
     plane_docker
-        .spawn_backend(&backend_name, &container_id, executor_config, None, None)
+        .spawn(&backend_name, executor_config, None, None)
         .await
         .unwrap();
 
-    let metrics = plane_docker.get_metrics(&container_id).await;
+    let metrics = plane_docker.metrics(&backend_name).await;
     assert!(metrics.is_ok());
     let mut metrics = metrics.unwrap();
     let prev_container_cpu = AtomicU64::new(0);

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -25,7 +25,6 @@ async fn test_get_metrics(_: TestEnvironment) {
     plane_docker.prepare(&executor_config).await.unwrap();
 
     let backend_name = BackendName::new_random();
-    let container_id = ContainerId::from(format!("plane-test-{}", backend_name));
 
     plane_docker
         .spawn(&backend_name, executor_config, None, None)

--- a/plane/src/drone/docker/commands.rs
+++ b/plane/src/drone/docker/commands.rs
@@ -1,4 +1,4 @@
-use super::{types::ContainerId, DockerRuntime};
+use super::{backend_id_to_container_id, types::ContainerId, DockerRuntime};
 use crate::{
     names::BackendName,
     protocol::AcquiredKey,
@@ -258,11 +258,12 @@ pub fn get_container_config_from_executor_config(
 pub async fn run_container(
     docker: &DockerRuntime,
     backend_id: &BackendName,
-    container_id: &ContainerId,
     exec_config: DockerExecutorConfig,
     acquired_key: Option<&AcquiredKey>,
     static_token: Option<&BearerToken>,
-) -> Result<()> {
+) -> Result<ContainerId> {
+    let container_id = backend_id_to_container_id(backend_id);
+
     let options = bollard::container::CreateContainerOptions {
         name: container_id.to_string(),
         ..Default::default()
@@ -288,7 +289,7 @@ pub async fn run_container(
         .start_container::<String>(&container_id.to_string(), None)
         .await?;
 
-    Ok(())
+    Ok(container_id)
 }
 
 #[cfg(test)]

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -41,7 +41,7 @@ pub mod types;
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
 fn backend_id_to_container_id(backend_id: &BackendName) -> ContainerId {
-    ContainerId::from(format!("plane-{}", backend_id.to_string()))
+    ContainerId::from(format!("plane-{}", backend_id))
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -41,6 +41,10 @@ pub mod types;
 /// The existence of this label is used to determine whether a container is managed by Plane.
 const PLANE_DOCKER_LABEL: &str = "dev.plane.backend";
 
+fn backend_id_to_container_id(backend_id: &BackendName) -> ContainerId {
+    ContainerId::from(format!("plane-{}", backend_id.to_string()))
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DockerRuntimeConfig {
     pub runtime: Option<String>,
@@ -108,7 +112,7 @@ impl DockerRuntime {
         Ok(())
     }
 
-    pub async fn backend_events(&self) -> impl Stream<Item = TerminateEvent> {
+    pub async fn events(&self) -> impl Stream<Item = TerminateEvent> {
         let options = EventsOptions {
             since: None,
             until: None,
@@ -175,24 +179,16 @@ impl DockerRuntime {
         })
     }
 
-    pub async fn spawn_backend(
+    pub async fn spawn(
         &self,
         backend_id: &BackendName,
-        container_id: &ContainerId,
         executable: DockerExecutorConfig,
         acquired_key: Option<&AcquiredKey>,
         static_token: Option<&BearerToken>,
     ) -> Result<SpawnResult> {
-        run_container(
-            self,
-            backend_id,
-            container_id,
-            executable,
-            acquired_key,
-            static_token,
-        )
-        .await?;
-        let port = get_port(&self.docker, container_id).await?;
+        let container_id =
+            run_container(self, backend_id, executable, acquired_key, static_token).await?;
+        let port = get_port(&self.docker, &container_id).await?;
 
         Ok(SpawnResult {
             container_id: container_id.clone(),
@@ -200,11 +196,9 @@ impl DockerRuntime {
         })
     }
 
-    pub async fn terminate_backend(
-        &self,
-        container_id: &ContainerId,
-        hard: bool,
-    ) -> Result<(), Error> {
+    pub async fn terminate(&self, backend_id: &BackendName, hard: bool) -> Result<(), Error> {
+        let container_id = backend_id_to_container_id(backend_id);
+
         if hard {
             self.docker
                 .kill_container::<String>(&container_id.to_string(), None)
@@ -223,10 +217,9 @@ impl DockerRuntime {
         Ok(())
     }
 
-    pub async fn get_metrics(
-        &self,
-        container_id: &ContainerId,
-    ) -> Result<bollard::container::Stats> {
+    pub async fn metrics(&self, backend_id: &BackendName) -> Result<bollard::container::Stats> {
+        let container_id = backend_id_to_container_id(backend_id);
+
         let options = StatsOptions {
             stream: false,
             one_shot: false,

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -33,7 +33,7 @@ impl Executor {
             let backends = backends.clone();
 
             GuardHandle::new(async move {
-                let mut events = docker.backend_events().await;
+                let mut events = docker.events().await;
                 while let Some(event) = events.next().await {
                     if let Some((_, manager)) = backends.remove(&event.backend_id) {
                         tracing::info!(


### PR DESCRIPTION
`ContainerId` is an implementation detail specific to Docker, but we pass it across the runtime interface a lot. This changes it so that we only ever pass `BackendName`s around, and derive the container ID from these names where necessary.

Part of #712 