### PR TITLE
Refactor metrics out of the executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1.0.50"
 time = "0.3.30"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-rustls = "0.24.1"
-tokio-stream = "0.1.14"
+tokio-stream = { version="0.1.14", features=["sync"] }
 tokio-tungstenite = { version = "0.20.1", features = ["rustls-tls-webpki-roots"] }
 tower-http = { version = "0.4.4", features = ["trace", "cors"] }
 tracing = "0.1.40"

--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
 use common::test_env::TestEnvironment;
 use common::timeout::WithTimeout;
-use futures_util::StreamExt;
 use plane::{
     drone::{
         docker::{DockerRuntime, DockerRuntimeConfig},
@@ -31,25 +28,7 @@ async fn test_get_metrics(_: TestEnvironment) {
         send.try_send(metrics_message).unwrap();
     });
 
-    let runtime = Arc::new(runtime);
-
     let backend_name = BackendName::new_random();
-
-    {
-        // TODO: metrics currently only works if events are being polled for the executor!
-        // This is always true in Plane, but is kind of an awkward coupling when it comes to tests.
-        // We should refactor the event loop.
-
-        let runtime = runtime.clone();
-        tokio::spawn(async move {
-            let mut events = runtime.events();
-
-            loop {
-                let event = events.next().await.unwrap();
-                tracing::info!("Event: {:?}", event);
-            }
-        });
-    }
 
     runtime
         .spawn(&backend_name, executor_config, None, None)

--- a/plane/src/drone/docker/metrics.rs
+++ b/plane/src/drone/docker/metrics.rs
@@ -1,0 +1,141 @@
+use super::{backend_id_to_container_id, types::ContainerId, MetricsCallback};
+use crate::{database::backend::BackendMetricsMessage, names::BackendName};
+use bollard::{container::StatsOptions, Docker};
+use futures_util::Stream;
+use std::sync::{Arc, Mutex};
+use tokio_stream::StreamExt;
+
+fn stream_metrics(
+    docker: &Docker,
+    container_id: &ContainerId,
+) -> impl Stream<Item = Result<bollard::container::Stats, bollard::errors::Error>> {
+    let options = StatsOptions {
+        stream: true,
+        one_shot: false,
+    };
+
+    docker.stats(container_id.as_str(), Some(options))
+}
+
+pub async fn metrics_loop(
+    backend_id: BackendName,
+    docker: Docker,
+    callback: Arc<Mutex<Option<MetricsCallback>>>,
+) {
+    let container_id = backend_id_to_container_id(&backend_id);
+
+    let mut stream = stream_metrics(&docker, &container_id);
+
+    while let Some(stats) = stream.next().await {
+        let stats = match stats {
+            Err(err) => {
+                tracing::error!(?err, "Error getting metrics for {container_id}");
+                break;
+            }
+            Ok(stats) => stats,
+        };
+
+        let callback = callback.lock().expect("Metrics callback lock poisoned");
+        if let Some(callback) = callback.as_ref() {
+            match metrics_message_from_container_stats(stats, backend_id.clone()) {
+                Ok(Some(metrics_message)) => {
+                    (callback)(metrics_message);
+                }
+                Ok(None) => (),
+                Err(err) => {
+                    tracing::error!(?err, "Error converting metrics for {container_id}");
+                }
+            }
+        }
+    }
+}
+
+fn metrics_message_from_container_stats(
+    stats: bollard::container::Stats,
+    backend_id: BackendName,
+) -> anyhow::Result<Option<BackendMetricsMessage>> {
+    let mem_stats = stats
+        .memory_stats
+        .stats
+        .ok_or_else(|| anyhow::anyhow!("No memory stats found in stats."))?;
+    let mem_used_total_docker = stats
+        .memory_stats
+        .usage
+        .ok_or_else(|| anyhow::anyhow!("No memory usage found in stats."))?;
+    let mem_limit = stats
+        .memory_stats
+        .limit
+        .ok_or_else(|| anyhow::anyhow!("No memory limit found in stats."))?;
+
+    let Some(total_system_cpu_used) = stats.cpu_stats.system_cpu_usage else {
+        tracing::info!("No system cpu usage found in stats (normal on first stats event).");
+        return Ok(None);
+    };
+    let Some(prev_total_system_cpu_used) = stats.precpu_stats.system_cpu_usage else {
+        tracing::info!(
+            "No previous system cpu usage found in stats (normal on first stats event)."
+        );
+        return Ok(None);
+    };
+
+    let container_cpu_used = stats.cpu_stats.cpu_usage.total_usage;
+    let prev_container_cpu_used = stats.precpu_stats.cpu_usage.total_usage;
+
+    if container_cpu_used < prev_container_cpu_used {
+        return Err(anyhow::anyhow!(
+            "Container cpu usage is less than previous total cpu usage."
+        ));
+    }
+    if total_system_cpu_used < prev_total_system_cpu_used {
+        return Err(anyhow::anyhow!(
+            "Total system cpu usage is less than previous total system cpu usage."
+        ));
+    }
+
+    let container_cpu_used_delta = container_cpu_used - prev_container_cpu_used;
+    let system_cpu_used_delta = total_system_cpu_used - prev_total_system_cpu_used;
+
+    let (mem_total, mem_active, mem_inactive, mem_unevictable, mem_used) = match mem_stats {
+        bollard::container::MemoryStatsStats::V1(v1_stats) => {
+            let active_mem = v1_stats.total_active_anon + v1_stats.total_active_file;
+            let total_mem = v1_stats.total_rss + v1_stats.total_cache;
+            let unevictable_mem = v1_stats.total_unevictable;
+            let inactive_mem = v1_stats.total_inactive_anon + v1_stats.total_inactive_file;
+            let mem_used = mem_used_total_docker - v1_stats.total_inactive_file;
+            (
+                total_mem,
+                active_mem,
+                inactive_mem,
+                unevictable_mem,
+                mem_used,
+            )
+        }
+        bollard::container::MemoryStatsStats::V2(v2_stats) => {
+            let active_mem = v2_stats.active_anon + v2_stats.active_file;
+            let kernel = v2_stats.kernel_stack + v2_stats.sock + v2_stats.slab;
+            let total_mem = v2_stats.file + v2_stats.anon + kernel;
+            let unevictable_mem = v2_stats.unevictable;
+            let inactive_mem = v2_stats.inactive_anon + v2_stats.inactive_file;
+            let mem_used = mem_used_total_docker - v2_stats.inactive_file;
+            (
+                total_mem,
+                active_mem,
+                inactive_mem,
+                unevictable_mem,
+                mem_used,
+            )
+        }
+    };
+
+    Ok(Some(BackendMetricsMessage {
+        backend_id,
+        mem_total,
+        mem_used,
+        mem_active,
+        mem_inactive,
+        mem_unevictable,
+        mem_limit,
+        cpu_used: container_cpu_used_delta,
+        sys_cpu: system_cpu_used_delta,
+    }))
+}

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -4,6 +4,7 @@ use self::{
 };
 use crate::{
     database::backend::BackendMetricsMessage,
+    drone::{docker::metrics::metrics_loop, runtime::Runtime},
     heartbeat_consts::KILL_AFTER_SOFT_TERMINATE_SECONDS,
     names::BackendName,
     protocol::AcquiredKey,
@@ -12,7 +13,7 @@ use crate::{
 };
 use anyhow::Result;
 use bollard::{
-    container::{PruneContainersOptions, StatsOptions, StopContainerOptions},
+    container::{PruneContainersOptions, StopContainerOptions},
     image::PruneImagesOptions,
     service::{EventMessage, HostConfigLogConfig},
     system::EventsOptions,
@@ -20,21 +21,16 @@ use bollard::{
 };
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-};
+use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, path::PathBuf};
-use thiserror::Error;
 use tokio_stream::{Stream, StreamExt};
 use valuable::Valuable;
-
-use super::runtime::Runtime;
 
 /// Clean up containers and images every minute.
 const CLEANUP_INTERVAL_SECS: i64 = 60;
 
 pub mod commands;
+pub mod metrics;
 pub mod types;
 
 /// The label used to identify containers managed by Plane.
@@ -56,11 +52,13 @@ pub struct DockerRuntimeConfig {
     pub cleanup_min_age: Option<Duration>,
 }
 
-#[derive(Clone, Debug)]
+pub type MetricsCallback = Box<dyn Fn(BackendMetricsMessage) + Send + Sync + 'static>;
+
 pub struct DockerRuntime {
     docker: Docker,
     config: DockerRuntimeConfig,
-    _cleanup_handle: Arc<GuardHandle>,
+    metrics_callback: Arc<Mutex<Option<MetricsCallback>>>,
+    _cleanup_handle: GuardHandle,
 }
 
 impl Runtime for DockerRuntime {
@@ -137,13 +135,13 @@ impl Runtime for DockerRuntime {
         Ok(())
     }
 
-    async fn events(&self) -> impl Stream<Item = TerminateEvent> {
+    fn events(&self) -> impl Stream<Item = TerminateEvent> {
         let options = EventsOptions {
             since: None,
             until: None,
             filters: vec![
                 ("type", vec!["container"]),
-                ("event", vec!["die", "stop"]),
+                ("event", vec!["die", "stop", "start"]),
                 ("label", vec![PLANE_DOCKER_LABEL]),
             ]
             .into_iter()
@@ -160,25 +158,38 @@ impl Runtime for DockerRuntime {
 
             tracing::info!(event=?e, "Received event");
 
-            let Some(actor) = e.actor else {
+            let Some(actor) = &e.actor else {
                 tracing::warn!("Received event without actor.");
                 return None;
             };
-            let Some(attributes) = actor.attributes else {
+            let Some(attributes) = &actor.attributes else {
                 tracing::warn!("Received event without attributes.");
                 return None;
             };
+            let Some(backend_id) = attributes.get(PLANE_DOCKER_LABEL) else {
+                tracing::warn!(?e.actor, "Ignoring event without Plane backend ID label.");
+                return None;
+            };
+
+            if e.action.as_deref() == Some("start") {
+                tracing::info!(backend_id = backend_id.as_value(), "Received start event.");
+
+                let Ok(backend_id) = BackendName::try_from(backend_id.to_string()) else {
+                    tracing::warn!(?e.actor, "Ignoring start event with invalid backend ID.");
+                    return None;
+                };
+                let docker = self.docker.clone();
+                let metrics_callback = self.metrics_callback.clone();
+                tracing::info!(%backend_id, "Spawning metrics loop.");
+                tokio::spawn(async move {
+                    metrics_loop(backend_id, docker, metrics_callback).await;
+                });
+
+                return None;
+            }
 
             let exit_code = attributes.get("exitCode");
             let exit_code = exit_code.and_then(|s| s.parse::<i32>().ok());
-            let Some(backend_id) = attributes.get(PLANE_DOCKER_LABEL) else {
-                tracing::warn!(
-                    "Ignoring event without Plane backend \
-                    ID (this is expected if non-Plane \
-                    backends are running on the same Docker instance.)"
-                );
-                return None;
-            };
             let backend_id = match BackendName::try_from(backend_id.to_string()) {
                 Ok(backend_id) => backend_id,
                 Err(err) => {
@@ -204,20 +215,9 @@ impl Runtime for DockerRuntime {
         })
     }
 
-    async fn metrics(&self, backend_id: &BackendName) -> Result<bollard::container::Stats> {
-        let container_id = backend_id_to_container_id(backend_id);
-
-        let options = StatsOptions {
-            stream: false,
-            one_shot: false,
-        };
-
-        self.docker
-            .stats(&container_id.to_string(), Some(options))
-            .next()
-            .await
-            .ok_or(anyhow::anyhow!("no stats found for {container_id}"))?
-            .map_err(|e| anyhow::anyhow!("{e:?}"))
+    fn metrics_callback<F: Fn(BackendMetricsMessage) + Send + Sync + 'static>(&self, sender: F) {
+        let mut lock = self.metrics_callback.lock().unwrap();
+        *lock = Some(Box::new(sender));
     }
 }
 
@@ -251,127 +251,13 @@ impl DockerRuntime {
             })
         };
 
-        let cleanup_handle = Arc::new(cleanup_handle);
-
         Ok(Self {
             docker,
             config,
+            metrics_callback: Arc::default(),
             _cleanup_handle: cleanup_handle,
         })
     }
-}
-
-#[derive(Error, Debug)]
-pub enum MetricsConversionError {
-    #[error("{0} stat not present in provided struct")]
-    NoStatsAvailable(String),
-    #[error("Measured cumulative system cpu use: {current} is less than previous cumulative total: {prev}")]
-    SysCpuLessThanCurrent { current: u64, prev: u64 },
-    #[error("Measured cumulative container cpu use: {current} is less than previous cumulative total: {prev}")]
-    ContainerCpuLessThanCurrent { current: u64, prev: u64 },
-}
-
-pub fn get_metrics_message_from_container_stats(
-    stats: bollard::container::Stats,
-    backend_id: BackendName,
-    prev_sys_cpu_ns: &AtomicU64,
-    prev_container_cpu_ns: &AtomicU64,
-) -> std::result::Result<BackendMetricsMessage, MetricsConversionError> {
-    let Some(mem_stats) = stats.memory_stats.stats else {
-        return Err(MetricsConversionError::NoStatsAvailable(
-            "memory_stats.stats".into(),
-        ));
-    };
-
-    let Some(total_system_cpu_used) = stats.cpu_stats.system_cpu_usage else {
-        return Err(MetricsConversionError::NoStatsAvailable(
-            "cpu_stats.system_cpu_usage".into(),
-        ));
-    };
-
-    let Some(mem_used_total_docker) = stats.memory_stats.usage else {
-        return Err(MetricsConversionError::NoStatsAvailable(
-            "memory_stats.usage".into(),
-        ));
-    };
-
-    let Some(mem_limit) = stats.memory_stats.limit else {
-        return Err(MetricsConversionError::NoStatsAvailable(
-            "memory_stats.limit".into(),
-        ));
-    };
-
-    let container_cpu_used = stats.cpu_stats.cpu_usage.total_usage;
-    let prev_sys_cpu_ns_load = prev_sys_cpu_ns.load(Ordering::SeqCst);
-    let prev_container_cpu_ns_load = prev_container_cpu_ns.load(Ordering::SeqCst);
-
-    if container_cpu_used < prev_container_cpu_ns_load {
-        return Err(MetricsConversionError::ContainerCpuLessThanCurrent {
-            current: container_cpu_used,
-            prev: prev_container_cpu_ns_load,
-        });
-    }
-    if total_system_cpu_used < prev_sys_cpu_ns_load {
-        return Err(MetricsConversionError::SysCpuLessThanCurrent {
-            current: total_system_cpu_used,
-            prev: prev_sys_cpu_ns_load,
-        });
-    }
-
-    let container_cpu_used_delta =
-        container_cpu_used - prev_container_cpu_ns.load(Ordering::SeqCst);
-
-    let system_cpu_used_delta = total_system_cpu_used - prev_sys_cpu_ns_load;
-
-    prev_container_cpu_ns.store(container_cpu_used, Ordering::SeqCst);
-    prev_sys_cpu_ns.store(total_system_cpu_used, Ordering::SeqCst);
-
-    // NOTE: a BIG limitation here is that docker does not report swap info!
-    // This may be important for scheduling decisions!
-
-    let (mem_total, mem_active, mem_inactive, mem_unevictable, mem_used) = match mem_stats {
-        bollard::container::MemoryStatsStats::V1(v1_stats) => {
-            let active_mem = v1_stats.total_active_anon + v1_stats.total_active_file;
-            let total_mem = v1_stats.total_rss + v1_stats.total_cache;
-            let unevictable_mem = v1_stats.total_unevictable;
-            let inactive_mem = v1_stats.total_inactive_anon + v1_stats.total_inactive_file;
-            let mem_used = mem_used_total_docker - v1_stats.total_inactive_file;
-            (
-                total_mem,
-                active_mem,
-                inactive_mem,
-                unevictable_mem,
-                mem_used,
-            )
-        }
-        bollard::container::MemoryStatsStats::V2(v2_stats) => {
-            let active_mem = v2_stats.active_anon + v2_stats.active_file;
-            let kernel = v2_stats.kernel_stack + v2_stats.sock + v2_stats.slab;
-            let total_mem = v2_stats.file + v2_stats.anon + kernel;
-            let unevictable_mem = v2_stats.unevictable;
-            let inactive_mem = v2_stats.inactive_anon + v2_stats.inactive_file;
-            let mem_used = mem_used_total_docker - v2_stats.inactive_file;
-            (
-                total_mem,
-                active_mem,
-                inactive_mem,
-                unevictable_mem,
-                mem_used,
-            )
-        }
-    };
-
-    Ok(BackendMetricsMessage {
-        backend_id,
-        mem_total,
-        mem_used,
-        mem_active,
-        mem_inactive,
-        mem_unevictable,
-        mem_limit,
-        cpu_used: container_cpu_used_delta,
-        sys_cpu: system_cpu_used_delta,
-    })
 }
 
 async fn cleanup_loop(docker: Docker, min_age: Duration, interval: Duration, auto_prune: bool) {

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -81,7 +81,6 @@ async fn events_loop(
         .into_iter()
         .collect(),
     };
-    //docker.events(Some(options)).filter_map(|e| {
     let mut stream = docker.events(Some(options));
 
     while let Some(e) = stream.next().await {

--- a/plane/src/drone/docker/types.rs
+++ b/plane/src/drone/docker/types.rs
@@ -10,6 +10,12 @@ impl From<String> for ContainerId {
     }
 }
 
+impl ContainerId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl Display for ContainerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &self.0)

--- a/plane/src/drone/state_store.rs
+++ b/plane/src/drone/state_store.rs
@@ -1,15 +1,12 @@
 use crate::{
-    database::backend::BackendMetricsMessage,
     log_types::LoggableTime,
     names::BackendName,
     protocol::{BackendEventId, BackendStateMessage},
-    typed_socket::TypedSocketSender,
     types::BackendState,
 };
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use rusqlite::Connection;
-use std::sync::{Arc, RwLock};
 
 /// An array of sqlite commands used to initialize the state store.
 /// These must be idempotent, because they are run every time a state store
@@ -38,10 +35,6 @@ pub struct StateStore {
 
     /// A function that is called when a backend's state changes.
     listener: Option<Box<dyn Fn(BackendStateMessage) + Send + Sync + 'static>>,
-
-    /// Sender for metrics
-    /// NOTE: downstream code assumes that this sender is refreshed on reconnect
-    metrics: Option<Arc<RwLock<TypedSocketSender<BackendMetricsMessage>>>>,
 }
 
 impl StateStore {
@@ -53,7 +46,6 @@ impl StateStore {
         Ok(Self {
             db_conn,
             listener: None,
-            metrics: None,
         })
     }
 
@@ -196,24 +188,6 @@ impl StateStore {
         self.listener = Some(Box::new(listener));
 
         Ok(())
-    }
-
-    pub fn register_metrics_sender(&mut self, sender: TypedSocketSender<BackendMetricsMessage>) {
-        if let Some(ref metrics) = self.metrics {
-            *metrics
-                .write()
-                .expect("backend metrics sender lock poisoned!") = sender;
-        } else {
-            self.metrics = Some(Arc::new(RwLock::new(sender)));
-        }
-    }
-
-    pub fn get_metrics_sender(
-        &self,
-    ) -> Result<Arc<RwLock<TypedSocketSender<BackendMetricsMessage>>>> {
-        self.metrics
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("metrics sender not initialized"))
     }
 
     pub fn ack_event(&self, event_id: BackendEventId) -> Result<()> {


### PR DESCRIPTION
This refactors metrics collection so that it lives entirely on the side of the runtime. This way, docker-specific things are confined to the Docker runtime.

The way it works is:

- `metrics()` on the `Runtime` trait is replaced with a `metrics_callback()` method, which can be used to pass in a callback that is called when metrics are available
- Container "start" events are added to the list of the events that the Docker runtime listens for (nb. these are currently only received if the events stream is being polled -- decoupling this is added as a todo)
- When a container start event is received, we pull the backend ID from the container metadata and start a tokio task which open a metrics stream for that container. When metrics are received, we convert them to a metrics message and invoke the callback.
