### PR TITLE
Make executor generic over runtime

### DIFF
--- a/plane/plane-tests/tests/backend_actions.rs
+++ b/plane/plane-tests/tests/backend_actions.rs
@@ -18,13 +18,16 @@ use std::time::Duration;
 mod common;
 
 /// Return a dummy connect request, which does not use a key.
-fn connect_request(cluster: &ClusterName) -> ConnectRequest<DockerExecutorConfig> {
+fn connect_request(cluster: &ClusterName) -> ConnectRequest {
+    let executable =
+        serde_json::to_value(DockerExecutorConfig::from_image_with_defaults("alpine")).unwrap();
+
     ConnectRequest {
         spawn_config: Some(SpawnConfig {
             id: None,
             cluster: Some(cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig::from_image_with_defaults("alpine"),
+            executable,
             lifetime_limit_seconds: None,
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/plane-tests/tests/backend_lifecycle.rs
+++ b/plane/plane-tests/tests/backend_lifecycle.rs
@@ -30,14 +30,15 @@ async fn backend_lifecycle(env: TestEnvironment) {
             id: None,
             cluster: Some(env.cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig {
+            executable: serde_json::to_value(DockerExecutorConfig {
                 image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
                 pull_policy: Some(PullPolicy::IfNotPresent),
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
-            },
+            })
+            .unwrap(),
             lifetime_limit_seconds: None,
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/plane-tests/tests/backend_status_in_response.rs
+++ b/plane/plane-tests/tests/backend_status_in_response.rs
@@ -25,14 +25,15 @@ async fn backend_status_in_response(env: TestEnvironment) {
             id: None,
             cluster: Some(env.cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig {
+            executable: serde_json::to_value(DockerExecutorConfig {
                 image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
                 pull_policy: Some(PullPolicy::IfNotPresent),
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
-            },
+            })
+            .unwrap(),
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/plane-tests/tests/drone_pools.rs
+++ b/plane/plane-tests/tests/drone_pools.rs
@@ -27,14 +27,15 @@ async fn drone_pools(env: TestEnvironment) {
             id: None,
             cluster: Some(env.cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig {
+            executable: serde_json::to_value(DockerExecutorConfig {
                 image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
                 pull_policy: Some(PullPolicy::IfNotPresent),
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
-            },
+            })
+            .unwrap(),
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/plane-tests/tests/reuse_key.rs
+++ b/plane/plane-tests/tests/reuse_key.rs
@@ -25,14 +25,15 @@ async fn reuse_key(env: TestEnvironment) {
             id: None,
             cluster: Some(env.cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig {
+            executable: serde_json::to_value(DockerExecutorConfig {
                 image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
                 pull_policy: Some(PullPolicy::IfNotPresent),
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
-            },
+            })
+            .unwrap(),
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/plane-tests/tests/subdomains.rs
+++ b/plane/plane-tests/tests/subdomains.rs
@@ -24,14 +24,15 @@ async fn subdomains(env: TestEnvironment) {
             id: None,
             cluster: Some(env.cluster.clone()),
             pool: DronePoolName::default(),
-            executable: DockerExecutorConfig {
+            executable: serde_json::to_value(DockerExecutorConfig {
                 image: "ghcr.io/drifting-in-space/demo-image-drop-four".to_string(),
                 pull_policy: Some(PullPolicy::IfNotPresent),
                 env: HashMap::default(),
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
-            },
+            })
+            .unwrap(),
             lifetime_limit_seconds: Some(5),
             max_idle_seconds: None,
             use_static_token: false,

--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -188,7 +188,8 @@ pub async fn run_admin_command_inner(opts: AdminOpts) -> Result<(), PlaneClientE
                 id,
                 cluster: cluster.clone(),
                 pool,
-                executable: executor_config.clone(),
+                executable: serde_json::to_value(&executor_config)
+                    .expect("Failed to serialize config"),
                 lifetime_limit_seconds: None,
                 max_idle_seconds: Some(max_idle_seconds),
                 use_static_token: static_token,

--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     typed_socket::client::TypedSocketConnector,
     types::{
         backend_state::BackendStatusStreamEntry, ClusterName, ClusterState, ConnectRequest,
-        ConnectResponse, DockerExecutorConfig, DrainResult, DronePoolName, RevokeRequest,
+        ConnectResponse, DrainResult, DronePoolName, RevokeRequest,
     },
 };
 use reqwest::{Response, StatusCode};
@@ -106,7 +106,7 @@ impl PlaneClient {
 
     pub async fn connect(
         &self,
-        connect_request: &ConnectRequest<DockerExecutorConfig>,
+        connect_request: &ConnectRequest,
     ) -> Result<ConnectResponse, PlaneClientError> {
         let addr = self.controller_address.join("/ctrl/connect");
 

--- a/plane/src/controller/connect.rs
+++ b/plane/src/controller/connect.rs
@@ -2,7 +2,7 @@ use super::error::{err_to_response, ApiErrorKind};
 use super::Controller;
 use crate::controller::error::IntoApiError;
 use crate::database::connect::ConnectError;
-use crate::types::{ConnectRequest, ConnectResponse, DockerExecutorConfig, RevokeRequest};
+use crate::types::{ConnectRequest, ConnectResponse, RevokeRequest};
 use axum::{extract::State, response::Response, Json};
 use reqwest::StatusCode;
 
@@ -67,7 +67,7 @@ fn connect_error_to_response(connect_error: &ConnectError) -> Response {
 
 pub async fn handle_connect(
     State(controller): State<Controller>,
-    Json(request): Json<ConnectRequest<DockerExecutorConfig>>,
+    Json(request): Json<ConnectRequest>,
 ) -> Result<Json<ConnectResponse>, Response> {
     let response = controller
         .connect(&request)

--- a/plane/src/controller/core.rs
+++ b/plane/src/controller/core.rs
@@ -3,7 +3,7 @@ use crate::{
     database::{connect::ConnectError, PlaneDatabase},
     names::{AnyNodeName, ControllerName},
     typed_socket::Handshake,
-    types::{ClusterName, ConnectRequest, ConnectResponse, DockerExecutorConfig, NodeId},
+    types::{ClusterName, ConnectRequest, ConnectResponse, NodeId},
 };
 use chrono::{DateTime, Utc};
 use std::net::IpAddr;
@@ -90,7 +90,7 @@ impl Controller {
 
     pub async fn connect(
         &self,
-        connect_request: &ConnectRequest<DockerExecutorConfig>,
+        connect_request: &ConnectRequest,
     ) -> Result<ConnectResponse, ConnectError> {
         let response = self
             .db

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -14,7 +14,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, str::FromStr};
+use std::{fmt::Debug, net::SocketAddr, str::FromStr};
 
 pub struct BackendDatabase<'a> {
     db: &'a PlaneDatabase,

--- a/plane/src/database/connect.rs
+++ b/plane/src/database/connect.rs
@@ -14,7 +14,7 @@ use crate::{
     protocol::{AcquiredKey, BackendAction, KeyDeadlines},
     types::{
         BackendState, BackendStatus, BearerToken, ClusterName, ConnectRequest, ConnectResponse,
-        DockerExecutorConfig, KeyConfig, RevokeRequest, SecretToken, SpawnConfig,
+        KeyConfig, RevokeRequest, SecretToken, SpawnConfig,
     },
     util::random_token,
 };
@@ -93,7 +93,7 @@ impl ConnectError {
 async fn create_backend_with_key(
     pool: &PgPool,
     key: &KeyConfig,
-    spawn_config: &SpawnConfig<DockerExecutorConfig>,
+    spawn_config: &SpawnConfig,
     cluster: &ClusterName,
     drone_for_spawn: &DroneForSpawn,
     static_token: Option<&BearerToken>,
@@ -171,7 +171,7 @@ async fn create_backend_with_key(
     };
 
     let pending_action = BackendAction::Spawn {
-        executable: Box::new(spawn_config.executable.clone()),
+        executable: spawn_config.executable.clone(),
         key: acquired_key,
         static_token: static_token.cloned(),
     };
@@ -232,7 +232,7 @@ pub async fn revoke(pool: &PgPool, request: &RevokeRequest) -> Result<()> {
 async fn attempt_connect(
     pool: &PgPool,
     default_cluster: Option<&ClusterName>,
-    request: &ConnectRequest<DockerExecutorConfig>,
+    request: &ConnectRequest,
     client: &PlaneClient,
 ) -> Result<ConnectResponse> {
     let key = if let Some(key) = &request.key {
@@ -361,7 +361,7 @@ async fn attempt_connect(
 pub async fn connect(
     pool: &PgPool,
     default_cluster: Option<&ClusterName>,
-    request: &ConnectRequest<DockerExecutorConfig>,
+    request: &ConnectRequest,
     client: &PlaneClient,
 ) -> Result<ConnectResponse> {
     let mut attempt = 1;

--- a/plane/src/database/mod.rs
+++ b/plane/src/database/mod.rs
@@ -12,7 +12,7 @@ use self::{
 };
 use crate::{
     client::PlaneClient,
-    types::{ClusterName, ConnectRequest, ConnectResponse, DockerExecutorConfig, RevokeRequest},
+    types::{ClusterName, ConnectRequest, ConnectResponse, RevokeRequest},
 };
 use serde_json::Value;
 use sqlx::{postgres::PgPoolOptions, PgPool};
@@ -91,7 +91,7 @@ impl PlaneDatabase {
     pub async fn connect(
         &self,
         default_cluster: Option<&ClusterName>,
-        request: &ConnectRequest<DockerExecutorConfig>,
+        request: &ConnectRequest,
         client: &PlaneClient,
     ) -> Result<ConnectResponse, ConnectError> {
         connect::connect(&self.pool, default_cluster, request, client).await

--- a/plane/src/drone/docker/mod.rs
+++ b/plane/src/drone/docker/mod.rs
@@ -240,7 +240,10 @@ impl Runtime for DockerRuntime {
     }
 
     fn metrics_callback<F: Fn(BackendMetricsMessage) + Send + Sync + 'static>(&self, sender: F) {
-        let mut lock = self.metrics_callback.lock().unwrap();
+        let mut lock = self
+            .metrics_callback
+            .lock()
+            .expect("Metrics callback lock poisoned.");
         *lock = Some(Box::new(sender));
     }
 }

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -18,14 +18,15 @@ use valuable::Valuable;
 pub struct Executor {
     pub runtime: Arc<DockerRuntime>,
     state_store: Arc<Mutex<StateStore>>,
-    backends: Arc<DashMap<BackendName, Arc<BackendManager>>>,
+    backends: Arc<DashMap<BackendName, Arc<BackendManager<DockerRuntime>>>>,
     ip: IpAddr,
     _backend_event_listener: GuardHandle,
 }
 
 impl Executor {
     pub fn new(runtime: Arc<DockerRuntime>, state_store: StateStore, ip: IpAddr) -> Self {
-        let backends: Arc<DashMap<BackendName, Arc<BackendManager>>> = Arc::default();
+        let backends: Arc<DashMap<BackendName, Arc<BackendManager<DockerRuntime>>>> =
+            Arc::default();
 
         let backend_event_listener = {
             let docker = runtime.clone();

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -37,10 +37,10 @@ pub mod runtime;
 mod state_store;
 mod wait_backend;
 
-pub async fn drone_loop(
+pub async fn drone_loop<R: Runtime>(
     name: DroneName,
     mut connection: TypedSocketConnector<MessageFromDrone>,
-    executor: Executor<DockerRuntime>,
+    executor: Executor<R>,
 ) {
     let executor = Arc::new(executor);
     let key_manager = Arc::new(Mutex::new(KeyManager::new(executor.clone())));

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -40,7 +40,7 @@ mod wait_backend;
 pub async fn drone_loop(
     name: DroneName,
     mut connection: TypedSocketConnector<MessageFromDrone>,
-    executor: Executor,
+    executor: Executor<DockerRuntime>,
 ) {
     let executor = Arc::new(executor);
     let key_manager = Arc::new(Mutex::new(KeyManager::new(executor.clone())));
@@ -100,7 +100,7 @@ pub async fn drone_loop(
                 }) => {
                     tracing::info!(
                         backend_id = backend_id.as_value(),
-                        action = action.as_value(),
+                        action = ?action,
                         "Received action."
                     );
 

--- a/plane/src/drone/runtime.rs
+++ b/plane/src/drone/runtime.rs
@@ -5,10 +5,11 @@ use crate::{
 };
 use anyhow::Error;
 use futures_util::{Future, Stream};
+use serde::de::DeserializeOwned;
 
 pub trait Runtime: Send + Sync + 'static {
     type RuntimeConfig;
-    type BackendConfig: Clone + Send + Sync + 'static;
+    type BackendConfig: Clone + Send + Sync + 'static + DeserializeOwned;
 
     fn prepare(
         &self,
@@ -33,5 +34,5 @@ pub trait Runtime: Send + Sync + 'static {
     /// any backend.
     fn metrics_callback<F: Fn(BackendMetricsMessage) + Send + Sync + 'static>(&self, sender: F);
 
-    fn events(&self) -> impl Stream<Item = TerminateEvent>;
+    fn events(&self) -> impl Stream<Item = TerminateEvent> + Send;
 }

--- a/plane/src/drone/runtime.rs
+++ b/plane/src/drone/runtime.rs
@@ -5,11 +5,11 @@ use crate::{
 };
 use anyhow::Error;
 use futures_util::{Future, Stream};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Runtime: Send + Sync + 'static {
     type RuntimeConfig;
-    type BackendConfig: Clone + Send + Sync + 'static + DeserializeOwned;
+    type BackendConfig: Clone + Send + Sync + 'static + DeserializeOwned + Serialize;
 
     fn prepare(
         &self,

--- a/plane/src/protocol.rs
+++ b/plane/src/protocol.rs
@@ -4,11 +4,12 @@ use crate::{
     names::{BackendActionName, BackendName},
     typed_socket::ChannelMessage,
     types::{
-        backend_state::TerminationReason, BackendState, BearerToken, ClusterName,
-        DockerExecutorConfig, KeyConfig, SecretToken, Subdomain, TerminationKind,
+        backend_state::TerminationReason, BackendState, BearerToken, ClusterName, KeyConfig,
+        SecretToken, Subdomain, TerminationKind,
     },
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Debug, Clone, valuable::Valuable)]
 pub struct KeyDeadlines {
@@ -38,10 +39,10 @@ pub struct AcquiredKey {
     pub token: i64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, valuable::Valuable)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum BackendAction {
     Spawn {
-        executable: Box<DockerExecutorConfig>,
+        executable: Value,
         key: AcquiredKey,
         static_token: Option<BearerToken>,
     },

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -309,7 +309,7 @@ impl KeyConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct ConnectRequest {
     /// Configuration for the key to use.
     #[serde(default)]
@@ -326,20 +326,6 @@ pub struct ConnectRequest {
     /// Passed to the backend through the X-Plane-Auth header.
     #[serde(default)]
     pub auth: Map<String, Value>,
-}
-
-// We need to derive this manually, because the derive macro will add a bound
-// EC: Default. This is not actually necessary because we default to spawn_config
-// being None.
-impl Default for ConnectRequest {
-    fn default() -> Self {
-        Self {
-            key: None,
-            spawn_config: None,
-            user: None,
-            auth: Map::default(),
-        }
-    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash, valuable::Valuable)]

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -246,7 +246,7 @@ impl DockerExecutorConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct SpawnConfig<EC> {
+pub struct SpawnConfig {
     /// ID to assign to the new backend. Must be unique.
     /// This should only be used if you really need it, otherwise you can leave it blank
     /// and let Plane assign a unique ID automatically. This may be removed from
@@ -261,7 +261,7 @@ pub struct SpawnConfig<EC> {
     pub pool: DronePoolName,
 
     /// Config to use to spawn the backend process.
-    pub executable: EC,
+    pub executable: Value,
 
     /// If provided, the maximum amount of time the backend will be allowed to
     /// stay alive. Time counts from when the backend is scheduled.
@@ -310,13 +310,13 @@ impl KeyConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct ConnectRequest<EC> {
+pub struct ConnectRequest {
     /// Configuration for the key to use.
     #[serde(default)]
     pub key: Option<KeyConfig>,
 
     /// Config to use if we need to create a new backend to connect to.
-    pub spawn_config: Option<SpawnConfig<EC>>,
+    pub spawn_config: Option<SpawnConfig>,
 
     /// Username or other identifier to associate with the generated connection URL.
     /// Passed to the backend through the X-Plane-User header.
@@ -331,7 +331,7 @@ pub struct ConnectRequest<EC> {
 // We need to derive this manually, because the derive macro will add a bound
 // EC: Default. This is not actually necessary because we default to spawn_config
 // being None.
-impl<EC> Default for ConnectRequest<EC> {
+impl Default for ConnectRequest {
     fn default() -> Self {
         Self {
             key: None,


### PR DESCRIPTION
- Removes generic parameter from JSON types (like `ConnectRequest`), instead using `serde_json::Value`
- Makes `BackendManager` generic over `Runtime`

Towards #712