### PR TITLE
Update artifact action to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run doctests
       run: cargo test --doc
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-scratch


### PR DESCRIPTION
v3 is deprecated (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)